### PR TITLE
Prevent escaping of HTML inside message content strings

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -112,9 +112,13 @@ chat_ui <- function(
       tag_name <- "shiny-chat-message"
     }
 
-    ui <- with_current_theme({
-      htmltools::renderTags(content)
-    })
+    # `content` is most likely a string, so avoid overhead in that case
+    # (it's also important that we *don't escape HTML* here).
+    if (is.character(content)) {
+      ui <- list(html = paste(content, collapse = "\n"))
+    } else {
+      ui <- with_current_theme(htmltools::renderTags(content))
+    }
 
     tag(
       tag_name,

--- a/R/markdown-stream.R
+++ b/R/markdown-stream.R
@@ -48,10 +48,14 @@ output_markdown_stream <- function(
   width = "100%",
   height = "auto"
 ) {
-
-  ui <- with_current_theme({
-    htmltools::renderTags(content)
-  })
+  
+  # `content` is most likely a string, so avoid overhead in that case
+  # (it's also important that we *don't escape HTML* here).
+  if (is.character(content)) {
+    ui <- list(html = paste(content, collapse="\n"))
+  } else {
+    ui <- with_current_theme(htmltools::renderTags(content))
+  }
 
   htmltools::tag(
     "shiny-markdown-stream",


### PR DESCRIPTION
Follow up to #29.

These changes mirror the fix made in https://github.com/posit-dev/py-shiny/pull/1939. See there for more context and a reprex