### PR TITLE
fix: Namespace `id` in `chat_append()` and friends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 # shinychat (development version)
 
 * Added new `output_markdown_stream()` and `markdown_stream()` functions to allow for streaming markdown content to the client. This is useful for showing Generative AI responses in real-time in a Shiny app, outside of a chat interface. (#23)
+
 * Both `chat_ui()` and `output_markdown_stream()` now support arbirary Shiny UI elements inside of messages. This allows for gathering input from the user (e.g., `selectInput()`), displaying of rich output (e.g., `{htmlwidgets}` like `{plotly}`), and more. (#1868)
+
 * Added a new `chat_clear()` function to clear the chat of all messages. (#25)
+
+* `chat_append()`, `chat_append_message()` and `chat_clear()` now all work in Shiny modules without needing to namespace the `id` of the Chat component. (#37)
 
 # shinychat 0.1.1
 

--- a/R/chat.R
+++ b/R/chat.R
@@ -237,7 +237,9 @@ chat_ui <- function(
 #'
 #' @export
 chat_append <- function(id, response, role = c("assistant", "user"), session = getDefaultReactiveDomain()) {
+  check_active_session(session)
   role <- match.arg(role)
+  
   stream <- as_generator(response)
   chat_append_stream(id, stream, role = role, session = session)
 }
@@ -312,6 +314,8 @@ chat_append <- function(id, response, role = c("assistant", "user"), session = g
 #'
 #' @export
 chat_append_message <- function(id, msg, chunk = TRUE, operation = c("append", "replace"), session = getDefaultReactiveDomain()) {
+  check_active_session(session)
+
   if (!is.list(msg)) {
     rlang::abort("msg must be a named list with 'role' and 'content' fields")
   }
@@ -366,7 +370,7 @@ chat_append_message <- function(id, msg, chunk = TRUE, operation = c("append", "
   )
 
   session$sendCustomMessage("shinyChatMessage", list(
-    id = id,
+    id = resolve_id(id, session),
     handler = msg_type,
     obj = msg
   ))
@@ -444,10 +448,12 @@ rlang::on_load(chat_append_stream_impl <- coro::async(function(id, stream, role 
 #'
 #' shinyApp(ui, server)
 chat_clear <- function(id, session = getDefaultReactiveDomain()) {
+  check_active_session(session)
+
   session$sendCustomMessage(
     "shinyChatMessage",
     list(
-      id = id,
+      id = resolve_id(id, session),
       handler = "shiny-chat-clear-messages",
       obj = NULL
     )

--- a/R/utils-shiny.R
+++ b/R/utils-shiny.R
@@ -1,0 +1,11 @@
+check_active_session <- function(session = shiny::getDefaultReactiveDomain()) {
+  rlang::abort(
+    "An active Shiny session is required.",
+    call = rlang::caller_env()
+  )
+}
+
+resolve_id <- function(id, session = shiny::getDefaultReactiveDomain()) {
+  if (is.null(session)) return(id)
+  session$ns(id)
+}


### PR DESCRIPTION
* Allows `chat_append()` to work in modules
* We also now check for an active Shiny session and throw early