### PR TITLE
feat: Use silent error in `chat_append()` to avoid crashing app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     rlang,
     shiny (>= 1.10.0)
 Suggests:
+    later,
     testthat (>= 3.0.0)
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * `chat_append()`, `chat_append_message()` and `chat_clear()` now all work in Shiny modules without needing to namespace the `id` of the Chat component. (#37)
 
+* `chat_append()` now logs and throws a silent error if the stream errors for any reason. This prevents the app from crashing if the stream is interrupted. You can still use `promises::catch()` to handle the error in your app code if desired. (#46)
+
 # shinychat 0.1.1
 
 * Initial CRAN submission.

--- a/R/chat.R
+++ b/R/chat.R
@@ -435,7 +435,6 @@ chat_append_stream <- function(
     class(reason) <- c("shiny.silent.error", class(reason))
     cnd_signal(reason)
   })
-  # result
 }
 
 utils:::globalVariables(c("generator_env", "exits", "yield"))

--- a/R/chat.R
+++ b/R/chat.R
@@ -414,10 +414,7 @@ chat_append_stream <- function(
       id,
       list(
         role = role,
-        content = paste0(
-          "\n\n**An error occurred:** ",
-          conditionMessage(reason)
-        )
+        content = sanitized_chat_error(reason)
       ),
       chunk = "end",
       operation = "append",
@@ -426,7 +423,7 @@ chat_append_stream <- function(
     rlang::warn(
       sprintf(
         "ERROR: An error occurred in `chat_append_stream(id=\"%s\")`",
-        id
+        session$ns(id)
       ),
       parent = reason
     )

--- a/R/chat.R
+++ b/R/chat.R
@@ -416,9 +416,6 @@ chat_append_stream <- function(
     cnd_signal(reason)
   })
 
-  # Note that we want to return a rejected promise (so the caller can see the
-  # error) that was already handled (so there's no "unhandled promise error"
-  # warning if the caller chooses not to do anything with it).
   promises::catch(result, function(reason) {
     chat_append_message(
       id,
@@ -439,6 +436,11 @@ chat_append_stream <- function(
     )
   })
 
+  # Note that we're not returning the result of `promises::catch()`, because we
+  # want to return a rejected promise so the caller can see the error. But we
+  # use the `catch()` both to make the error visible to the user *and* to ensure
+  # there's no "unhandled promise error" warning if the caller chooses not to do
+  # anything with it.
   result
 }
 

--- a/R/chat.R
+++ b/R/chat.R
@@ -423,13 +423,22 @@ chat_append_stream <- function(
       operation = "append",
       session = session
     )
+    rlang::warn(
+      sprintf(
+        "ERROR: An error occurred in `chat_append_stream(id=\"%s\")`",
+        id
+      ),
+      parent = reason
+    )
+    # ...but rethrow the error as a silent error, so the caller can also handle
+    # it if they want, but it won't bring down the app. Note that we want to
+    # return a rejected promise (so the caller can see the error) that was
+    # already handled (so there's no "unhandled promise error" warning if the
+    # caller chooses not to do anything with it).
+    class(reason) <- c("shiny.silent.error", class(reason))
+    cnd_signal(reason)
   })
-  # ...but also return it, so the caller can also handle it if they want. Note
-  # that we're not returning the result of `promises::catch`; we want to return
-  # a rejected promise (so the caller can see the error) that was already
-  # handled (so there's no "unhandled promise error" warning if the caller
-  # chooses not to do anything with it).
-  result
+  # result
 }
 
 utils:::globalVariables(c("generator_env", "exits", "yield"))

--- a/R/chat_app.R
+++ b/R/chat_app.R
@@ -157,68 +157,10 @@ chat_mod_server <- function(id, client) {
       )
     })
 
-    shiny::observe({
-      if (append_stream_task$status() == "error") {
-        tryCatch(
-          append_stream_task$result(),
-          error = notify_error("chat", session = session, module_id = id)
-        )
-      }
-    })
-
     shiny::reactive({
       if (append_stream_task$status() == "success") {
         client$last_turn()
       }
     })
   })
-}
-
-notify_error <- function(
-  id,
-  module_id,
-  session = shiny::getDefaultReactiveDomain()
-) {
-  function(err) {
-    rlang::warn(
-      sprintf(
-        "ERROR: An error occurred in `chat_mod_server(id=\"%s\")`",
-        module_id
-      ),
-      parent = err
-    )
-
-    needs_sanitized <-
-      isTRUE(getOption("shiny.sanitize.errors")) &&
-      !inherits(err, "shiny.custom.error")
-    if (needs_sanitized) {
-      msg <- "**An error occurred.** Please try again or contact the app author."
-    } else {
-      msg <- sprintf(
-        "**An error occurred:**\n\n```\n%s\n```",
-        strip_ansi(conditionMessage(err))
-      )
-    }
-
-    chat_append_message(
-      id,
-      msg = list(role = "assistant", content = msg),
-      chunk = TRUE,
-      operation = "append",
-      session = session
-    )
-    chat_append_message(
-      id,
-      list(role = "assistant", content = ""),
-      chunk = "end",
-      operation = "append",
-      session = session
-    )
-  }
-}
-
-strip_ansi <- function(text) {
-  # Matches codes like "\x1B[31;43m", "\x1B[1;3;4m"
-  ansi_pattern <- "(\x1B|\x033)\\[[0-9;?=<>]*[@-~]"
-  gsub(ansi_pattern, "", text)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,20 @@
+sanitized_chat_error <- function(err) {
+  needs_sanitized <-
+    isTRUE(getOption("shiny.sanitize.errors")) &&
+    !inherits(err, "shiny.custom.error")
+
+  if (needs_sanitized) {
+    "\n\n**An error occurred.** Please try again or contact the app author."
+  } else {
+    sprintf(
+      "\n\n**An error occurred:**\n\n```\n%s\n```",
+      strip_ansi(conditionMessage(err))
+    )
+  }
+}
+
+strip_ansi <- function(text) {
+  # Matches codes like "\x1B[31;43m", "\x1B[1;3;4m"
+  ansi_pattern <- "(\x1B|\x033)\\[[0-9;?=<>]*[@-~]"
+  gsub(ansi_pattern, "", text)
+}

--- a/man/shinychat-package.Rd
+++ b/man/shinychat-package.Rd
@@ -11,9 +11,9 @@ Provides a scrolling chat interface with multiline input, suitable for creating 
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/jcheng5/shinychat}
-  \item \url{https://jcheng5.github.io/shinychat/}
-  \item Report bugs at \url{https://github.com/jcheng5/shinychat/issues}
+  \item \url{https://github.com/posit-dev/shinychat}
+  \item \url{https://posit-dev.github.io/shinychat/}
+  \item Report bugs at \url{https://github.com/posit-dev/shinychat/issues}
 }
 
 }
@@ -23,6 +23,7 @@ Useful links:
 Authors:
 \itemize{
   \item Carson Sievert \email{carson@posit.co}
+  \item Garrick Aden-Buie \email{garrick@adenbuie.com} (\href{https://orcid.org/0000-0002-7111-0077}{ORCID})
 }
 
 Other contributors:

--- a/tests/testthat/helper-sync.R
+++ b/tests/testthat/helper-sync.R
@@ -1,0 +1,30 @@
+# Given a promise-yielding expression, loop until it resolves or rejects.
+# DON'T USE THIS TECHNIQUE IN SHINY, PLUMBER, OR HTTPUV CONTEXTS.
+sync <- function(expr) {
+  p <- force(expr)
+
+  done <- FALSE
+  success <- NULL
+  error <- NULL
+
+  promises::then(
+    p,
+    function(result) {
+      success <<- result
+      done <<- TRUE
+    },
+    function(err) {
+      error <<- err
+      done <<- TRUE
+    }
+  )
+
+  while (!done) {
+    later::run_now(0.25)
+  }
+  if (!is.null(error)) {
+    stop(error)
+  } else {
+    success
+  }
+}

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -41,3 +41,32 @@ test_that("Chat component markup", {
 
   # TODO: it'd be nice to mock the shinyChatMessage custom messages
 })
+
+test_that("chat_append_stream() handles errors in the stream", {
+  local_mocked_bindings(
+    chat_append_message = coro::async(function(...) invisible())
+  )
+
+  shiny::withReactiveDomain(shiny::MockShinySession$new(), {
+    stream <- coro::async_generator(function() {
+      for (i in 1:3) {
+        yield(i)
+      }
+      stop("boom")
+    })
+
+    p <- chat_append_stream("chat", stream())
+    expect_warning(
+      res <- tryCatch(sync(p), error = identity),
+      regexp = 'chat_append_stream'
+    )
+
+    expect_s3_class(p, "promise")
+    expect_true(promises::is.promise(p))
+    expect_equal(attr(p, "promise_impl")$status(), "rejected")
+
+    expect_s3_class(res, class = c("condition", "error"))
+    expect_s3_class(res, class = "shiny.silent.error")
+    expect_equal(conditionMessage(res), "boom")
+  })
+})


### PR DESCRIPTION
This PR updates `chat_append_stream()` such that an error thrown here will not crash the app if `chat_append()` ends an `observeEvent()` block.

## Test cases

### `chat_ui()`

```r
library(shiny)
library(bslib)
library(ellmer)
pkgload::load_all()

# Force ellmer to throw an error ----
value_turn <- S7::new_external_generic(
  "ellmer",
  "value_turn",
  "provider"
)

S7::method(value_turn, ellmer:::ProviderOpenAI) <- function(
  provider,
  result,
  has_type = FALSE
) {
  ellmer::Turn(NULL)
}
# ----

client <- ellmer::chat_openai(model = "gpt-4.1-nano")

ui <- page_fluid(
  chat_ui("chat"),
)

server <- function(input, output, session) {
  observeEvent(input$chat_user_input, {
    stream <- client$stream_async(input$chat_user_input)
    chat_append("chat", stream)$catch(function(err) {
      message("Error happened: ", conditionMessage(err))
    })
  })
}

shinyApp(ui, server)
```

In console

```
Warning: ERROR: An error occurred in `chat_append_stream(id="chat")`
Caused by error:
! <ellmer::Turn> object properties are invalid:
- @role must be <character>, not <NULL>
```

In app

![image](https://github.com/user-attachments/assets/a217642b-4061-4707-b1f0-2bb5d22a2bbe)


### `chat_mod_server()`

```r
library(shiny)
library(bslib)
library(ellmer)
pkgload::load_all()

# Force ellmer to throw an error ----
value_turn <- S7::new_external_generic(
  "ellmer",
  "value_turn",
  "provider"
)

S7::method(value_turn, ellmer:::ProviderOpenAI) <- function(
  provider,
  result,
  has_type = FALSE
) {
  ellmer::Turn(NULL)
}
# ----

client <- ellmer::chat_openai(model = "gpt-4.1-nano")

ui <- page_fluid(
  chat_mod_ui("chat"),
)

server <- function(input, output, session) {
  chat_mod_server("chat", client)
}

shinyApp(ui, server)
```

In console

```
Warning: ERROR: An error occurred in `chat_append_stream(id="chat-chat")`
Caused by error:
! <ellmer::Turn> object properties are invalid:
- @role must be <character>, not <NULL>
```

In app

![image](https://github.com/user-attachments/assets/a302da7a-3a8f-4746-826d-312c9aaa34c2)

