### PR TITLE
feat: Export and test MarkdownStream

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -7,3 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* The `shinychat` package was created from the `shiny.ui.Chat` and
+  `shiny.ui.MarkdownStream` components as a new package. These components will
+  still be available in the `shiny` package, but by separating the `shinychat`
+  package we can more easily maintain and develop these components independently with a faster release cycle.

--- a/pkg-py/src/shinychat/__init__.py
+++ b/pkg-py/src/shinychat/__init__.py
@@ -1,3 +1,4 @@
-from ._chat import Chat, ChatExpress, chat_ui
+from ._chat import Chat, chat_ui
+from ._markdown_stream import MarkdownStream, output_markdown_stream
 
-__all__ = ["Chat", "ChatExpress", "chat_ui"]
+__all__ = ["Chat", "chat_ui", "MarkdownStream", "output_markdown_stream"]

--- a/pkg-py/src/shinychat/express/__init__.py
+++ b/pkg-py/src/shinychat/express/__init__.py
@@ -1,3 +1,4 @@
 from .._chat import ChatExpress as Chat
+from .._markdown_stream import ExpressMarkdownStream as MarkdownStream
 
-__all__ = ["Chat"]
+__all__ = ["Chat", "MarkdownStream"]

--- a/pkg-py/tests/playwright/MarkdownStream/basic/README.md
+++ b/pkg-py/tests/playwright/MarkdownStream/basic/README.md
@@ -1,0 +1,63 @@
+# Shiny for Python
+
+[![PyPI Latest Release](https://img.shields.io/pypi/v/shiny.svg)](https://pypi.org/project/shiny/)
+[![Build status](https://img.shields.io/github/actions/workflow/status/posit-dev/py-shiny/pytest.yaml?branch=main)](https://img.shields.io/github/actions/workflow/status/posit-dev/py-shiny/pytest.yaml?branch=main)
+[![Conda Latest Release](https://anaconda.org/conda-forge/shiny/badges/version.svg)](https://anaconda.org/conda-forge/shiny)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/shiny)](https://pypi.org/project/shiny/)
+[![License](https://img.shields.io/github/license/posit-dev/py-shiny)](https://github.com/posit-dev/py-shiny/blob/main/LICENSE)
+
+Shiny for Python is the best way to build fast, beautiful web applications in Python. You can build quickly with Shiny and create simple interactive visualizations and prototype applications in an afternoon. But unlike other frameworks targeted at data scientists, Shiny does not limit your app's growth. Shiny remains extensible enough to power large, mission-critical applications.
+
+To learn more about Shiny see the [Shiny for Python website](https://shiny.posit.co/py/). If you're new to the framework we recommend these resources:
+
+- How [Shiny is different](https://posit.co/blog/why-shiny-for-python/) from Dash and Streamlit.
+
+- How [reactive programming](https://shiny.posit.co/py/docs/reactive-programming.html) can help you build better applications.
+
+- How to [use modules](https://shiny.posit.co/py/docs/workflow-modules.html) to efficiently develop large applications.
+
+- Hosting applications for free on [shinyapps.io](https://shiny.posit.co/py/docs/deploy.html#deploy-to-shinyapps.io-cloud-hosting), [Hugging Face](https://shiny.posit.co/blog/posts/shiny-on-hugging-face/), or [Shinylive](https://shiny.posit.co/py/docs/shinylive.html).
+
+## Join the conversation
+
+If you have questions about Shiny for Python, or want to help us decide what to work on next, [join us on Discord](https://discord.gg/yMGCamUMnS).
+
+## Getting started
+
+To get started with shiny follow the [installation instructions](https://shiny.posit.co/py/docs/install-create-run.html) or just install it from pip.
+
+```sh
+pip install shiny
+```
+
+To install the latest development version:
+
+```sh
+# First install htmltools, then shiny
+pip install git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools
+pip install git+https://github.com/posit-dev/py-shiny.git#egg=shiny
+```
+
+You can create and run your first application with `shiny create`, the CLI will ask you which template you would like to use. You can either run the app with the Shiny extension, or call `shiny run app.py --reload --launch-browser`.
+
+## Development
+
+* Shinylive built from the `main` branch: https://posit-dev.github.io/py-shiny/shinylive/py/examples/
+* API documentation for the `main` branch:
+    * https://posit-dev.github.io/py-shiny/docs/api/express/
+    * https://posit-dev.github.io/py-shiny/docs/api/core/
+
+If you want to do development on Shiny for Python:
+
+```sh
+pip install -e ".[dev,test]"
+```
+
+Additionally, you can install pre-commit hooks which will automatically reformat and lint the code when you make a commit:
+
+```sh
+pre-commit install
+
+# To disable:
+# pre-commit uninstall
+```

--- a/pkg-py/tests/playwright/MarkdownStream/basic/app.py
+++ b/pkg-py/tests/playwright/MarkdownStream/basic/app.py
@@ -1,0 +1,72 @@
+import asyncio
+from pathlib import Path
+
+from shiny import reactive
+from shiny.express import render, ui
+from shinychat.express import MarkdownStream
+
+# Read in the py-shiny README.md file
+readme = Path(__file__).parent / "README.md"
+with open(readme, "r") as f:
+    readme_chunks = f.read().replace("\n", " \n ").split(" ")
+
+
+stream = MarkdownStream("shiny_readme")
+stream_err = MarkdownStream("shiny_readme_err")
+
+
+async def readme_generator():
+    for chunk in readme_chunks:
+        await asyncio.sleep(0.005)
+        yield chunk + " "
+
+
+def readme_generator_err():
+    for chunk in readme_chunks:
+        yield chunk + " "
+        if chunk == "Shiny":
+            raise RuntimeError("boom!")
+
+
+@reactive.effect
+async def _():
+    await stream.stream(readme_generator())
+    await stream_err.stream(readme_generator_err())
+
+
+with ui.card(
+    height="400px",
+    class_="mt-3",
+):
+    ui.card_header("Shiny README.md")
+    stream.ui()
+
+
+with ui.card(class_="mt-3"):
+    ui.card_header("Shiny README.md with error")
+    stream_err.ui()
+
+
+basic_stream = MarkdownStream("basic_stream_result")
+basic_stream.ui()
+
+
+def basic_generator():
+    yield "Basic "
+    yield "stream"
+
+
+@reactive.calc
+async def stream_task():
+    return await basic_stream.stream(basic_generator())
+
+
+@reactive.effect
+async def _():
+    await stream_task()
+
+
+@render.text
+async def stream_result():
+    task = await stream_task()
+    return f"Stream result: {task.result()}"

--- a/pkg-py/tests/playwright/MarkdownStream/basic/test_stream_basic.py
+++ b/pkg-py/tests/playwright/MarkdownStream/basic/test_stream_basic.py
@@ -1,0 +1,50 @@
+from playwright.sync_api import Page, expect
+from shiny.playwright import controller
+from shiny.run import ShinyAppProc
+
+
+def is_element_scrolled_to_bottom(page: Page, selector: str) -> bool:
+    return page.evaluate(
+        """(selector) => {
+        const element = document.querySelector(selector);
+        if (!element) return false;
+
+        // Get the exact scroll values (rounded to handle float values)
+        const scrollTop = Math.round(element.scrollTop);
+        const scrollHeight = Math.round(element.scrollHeight);
+        const clientHeight = Math.round(element.clientHeight);
+
+        // Check if the element is scrollable
+        if (scrollHeight <= clientHeight) return false;
+
+        // Check if we're at the bottom (allowing for 1px difference due to rounding)
+        return Math.abs((scrollTop + clientHeight) - scrollHeight) <= 1;
+    }""",
+        selector,
+    )
+
+
+def test_validate_stream_basic(page: Page, local_app: ShinyAppProc) -> None:
+    page.goto(local_app.url)
+
+    stream = page.locator("#shiny_readme")
+    expect(stream).to_be_visible(timeout=30 * 1000)
+    expect(stream).to_contain_text("pip install shiny")
+
+    # Check that the card body container (the parent of the markdown stream) is scrolled
+    # all the way to the bottom
+    is_scrolled = is_element_scrolled_to_bottom(page, ".card-body")
+    assert is_scrolled, (
+        "The card body container should be scrolled to the bottom"
+    )
+
+    stream2 = page.locator("#shiny_readme_err")
+    expect(stream2).to_be_visible(timeout=30 * 1000)
+    expect(stream2).to_contain_text("Shiny")
+
+    notification = page.locator(".shiny-notification-error")
+    expect(notification).to_be_visible(timeout=30 * 1000)
+    expect(notification).to_contain_text("boom!")
+
+    txt_result = controller.OutputText(page, "stream_result")
+    txt_result.expect_value("Stream result: Basic stream")

--- a/pkg-py/tests/playwright/MarkdownStream/shiny_ui/app.py
+++ b/pkg-py/tests/playwright/MarkdownStream/shiny_ui/app.py
@@ -1,0 +1,40 @@
+from shiny import reactive
+from shiny.express import input, render, ui
+from shinychat.express import MarkdownStream
+
+md_stream = MarkdownStream("stream")
+md_stream.ui(
+    content=ui.TagList(
+        "**Hello! Here are a couple inputs:**",
+        ui.div(
+            ui.input_select(
+                "select", "", choices=["a", "b", "c"], width="fit-content"
+            ),
+            ui.input_switch("toggle", "Toggle", width="fit-content"),
+            ui.input_action_button("insert_input", "Insert another input"),
+            class_="d-flex gap-5",
+        ),
+        ui.div(
+            ui.head_content(ui.tags.style("#chat { color: #29465B; }")),
+        ),
+    )
+)
+
+
+@reactive.effect
+@reactive.event(input.insert_input)
+async def _():
+    await md_stream.stream(
+        ["Here's a dynamically added input: ", ui.input_text("text", "")],
+        clear=False,
+    )
+
+
+@render.code
+def input_vals():
+    return f"Selected: {input.select()} Toggled: {input.toggle()}"
+
+
+@render.code
+def dynamic_input_output():
+    return f"Dynamic input value: '{input.text()}'"

--- a/pkg-py/tests/playwright/MarkdownStream/shiny_ui/test_stream_shiny_ui.py
+++ b/pkg-py/tests/playwright/MarkdownStream/shiny_ui/test_stream_shiny_ui.py
@@ -1,0 +1,45 @@
+from playwright.sync_api import Page, expect
+from shiny.playwright import controller
+from shiny.run import ShinyAppProc
+
+
+def test_validate_stream_shiny_ui(page: Page, local_app: ShinyAppProc) -> None:
+    page.goto(local_app.url)
+
+    TIMEOUT = 30 * 1000
+
+    stream = page.locator("#stream")
+    expect(stream).to_be_visible(timeout=TIMEOUT)
+
+    select = controller.InputSelect(page, "select")
+    expect(select.loc).to_be_visible(timeout=TIMEOUT)
+
+    toggle = controller.InputSwitch(page, "toggle")
+    expect(toggle.loc).to_be_visible(timeout=TIMEOUT)
+
+    insert_input = controller.InputActionButton(page, "insert_input")
+    expect(insert_input.loc).to_be_visible(timeout=TIMEOUT)
+
+    input_vals = controller.OutputCode(page, "input_vals")
+    expect(input_vals.loc).to_be_visible(timeout=TIMEOUT)
+
+    dynamic_input_output = controller.OutputCode(page, "dynamic_input_output")
+    expect(dynamic_input_output.loc).to_be_visible(timeout=TIMEOUT)
+
+    # Test initial state
+    input_vals.expect_value("Selected: a Toggled: False")
+
+    # State changes
+    select.set("b")
+    input_vals.expect_value("Selected: b Toggled: False")
+    toggle.set(True)
+    input_vals.expect_value("Selected: b Toggled: True")
+
+    # Clicking should insert text input
+    insert_input.click()
+    text = controller.InputText(page, "text")
+    expect(text.loc).to_be_visible(timeout=TIMEOUT)
+
+    # Check the dynamic input value can be read
+    text.set("Some value")
+    dynamic_input_output.expect_value("Dynamic input value: 'Some value'")

--- a/pkg-py/tests/playwright/MarkdownStream/stream-result/app.py
+++ b/pkg-py/tests/playwright/MarkdownStream/stream-result/app.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from shiny import reactive
+from shiny.express import input, render, ui
+from shinychat.express import MarkdownStream
+
+stream = MarkdownStream("stream_id")
+stream.ui()
+
+
+ui.input_action_button("do_stream", "Do stream")
+
+
+async def gen():
+    yield "Hello "
+    await asyncio.sleep(0.1)
+    yield "world!"
+
+
+@reactive.effect
+@reactive.event(input.do_stream)
+async def _():
+    await stream.stream(gen())
+
+
+@render.code
+def stream_result():
+    res = stream.latest_stream.result()
+    return f"Stream result: {res}"

--- a/pkg-py/tests/playwright/MarkdownStream/stream-result/test_latest_stream_result.py
+++ b/pkg-py/tests/playwright/MarkdownStream/stream-result/test_latest_stream_result.py
@@ -1,0 +1,17 @@
+from playwright.sync_api import Page, expect
+from shiny.playwright import controller
+from shiny.run import ShinyAppProc
+
+
+def test_latest_stream_result(page: Page, local_app: ShinyAppProc) -> None:
+    page.goto(local_app.url)
+
+    stream = page.locator("#stream_id")
+    stream_result = controller.OutputCode(page, "stream_result")
+    stream_result.expect_value("")
+
+    btn = controller.InputActionButton(page, "do_stream")
+    btn.click()
+
+    expect(stream).to_contain_text("Hello world!")
+    stream_result.expect_value("Stream result: Hello world!")


### PR DESCRIPTION
Follow up to #56

Exposes `shinychat.MarkdownStream`, `shinychat.output_markdown_stream()` and `shinychat.express.MarkdownStream` and brings the markdown stream playwright tests from py-shiny into shinychat