### PR TITLE
Make chat_app refresh its prepopulated UI messages on reload

### DIFF
--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -4,6 +4,8 @@
 
 * Added `chat_enable_bookmarking()` which adds Shiny bookmarking hooks to save and restore the `{ellmer}` chat client. (#28)
 
+* `chat_app()` now correctly restores the chat client state when refreshing the app, e.g. by reloading the page. (#71)
+
 # shinychat 0.2.0
 
 ## New features and improvements

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -13,7 +13,7 @@
 #' @examples
 #' \dontrun{
 #' # Interactive in the console ----
-#' client <- ellmer::chat_claude()
+#' client <- ellmer::chat_anthropic()
 #' chat_app(client)
 #'
 #' # Inside a Shiny app ----
@@ -47,7 +47,7 @@
 #' )
 #'
 #' server <- function(input, output, session) {
-#'   claude <- ellmer::chat_claude(model = "claude-3-5-sonnet-latest") # Requires ANTHROPIC_API_KEY
+#'   claude <- ellmer::chat_anthropic(model = "claude-3-5-sonnet-latest") # Requires ANTHROPIC_API_KEY
 #'   openai <- ellmer::chat_openai(model = "gpt-4o") # Requires OPENAI_API_KEY
 #'
 #'   chat_mod_server("claude", claude)

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -69,15 +69,17 @@
 chat_app <- function(client, ...) {
   check_ellmer_chat(client)
 
-  ui <- bslib::page_fillable(
-    chat_mod_ui("chat", client = client, height = "100%"),
-    shiny::actionButton(
-      "close_btn",
-      label = "",
-      class = "btn-close",
-      style = "position: fixed; top: 6px; right: 6px;"
+  ui <- function(req) {
+    bslib::page_fillable(
+      chat_mod_ui("chat", client = client, height = "100%"),
+      shiny::actionButton(
+        "close_btn",
+        label = "",
+        class = "btn-close",
+        style = "position: fixed; top: 6px; right: 6px;"
+      )
     )
-  )
+  }
 
   server <- function(input, output, session) {
     chat_mod_server("chat", client)

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -5,6 +5,11 @@
 #' Note that these functions will mutate the input `client` object as
 #' you chat because your turns will be appended to the history.
 #'
+#' The app created by `chat_app()` is suitable for interactive use by a single
+#' user. For multi-user Shiny apps, use the Shiny module chat functions --
+#' `chat_mod_ui()` and `chat_mod_server()` -- and be sure to create a new chat
+#' client for each user session.
+#'
 #' @examples
 #' \dontrun{
 #' # Interactive in the console ----
@@ -64,7 +69,9 @@
 #'   * `chat_mod_server()` includes the shinychat module server logic, and
 #'     and returns the last turn upon successful chat completion.
 #'
-#' @describeIn chat_app A simple Shiny app for live chatting.
+#' @describeIn chat_app A simple Shiny app for live chatting. Note that this
+#'   app is suitable for interactive use by a single user; do not use
+#'   `chat_app()` in a multi-user Shiny app context.
 #' @export
 chat_app <- function(client, ...) {
   check_ellmer_chat(client)

--- a/pkg-r/man/chat_app.Rd
+++ b/pkg-r/man/chat_app.Rd
@@ -38,10 +38,17 @@ and returns the last turn upon successful chat completion.
 Create a simple Shiny app for live chatting using an \link[ellmer:Chat]{ellmer::Chat} object.
 Note that these functions will mutate the input \code{client} object as
 you chat because your turns will be appended to the history.
+
+The app created by \code{chat_app()} is suitable for interactive use by a single
+user. For multi-user Shiny apps, use the Shiny module chat functions --
+\code{chat_mod_ui()} and \code{chat_mod_server()} -- and be sure to create a new chat
+client for each user session.
 }
 \section{Functions}{
 \itemize{
-\item \code{chat_app()}: A simple Shiny app for live chatting.
+\item \code{chat_app()}: A simple Shiny app for live chatting. Note that this
+app is suitable for interactive use by a single user; do not use
+\code{chat_app()} in a multi-user Shiny app context.
 
 \item \code{chat_mod_ui()}: A simple chat app module UI.
 

--- a/pkg-r/man/chat_app.Rd
+++ b/pkg-r/man/chat_app.Rd
@@ -58,7 +58,7 @@ app is suitable for interactive use by a single user; do not use
 \examples{
 \dontrun{
 # Interactive in the console ----
-client <- ellmer::chat_claude()
+client <- ellmer::chat_anthropic()
 chat_app(client)
 
 # Inside a Shiny app ----
@@ -92,7 +92,7 @@ ui <- page_fillable(
 )
 
 server <- function(input, output, session) {
-  claude <- ellmer::chat_claude(model = "claude-3-5-sonnet-latest") # Requires ANTHROPIC_API_KEY
+  claude <- ellmer::chat_anthropic(model = "claude-3-5-sonnet-latest") # Requires ANTHROPIC_API_KEY
   openai <- ellmer::chat_openai(model = "gpt-4o") # Requires OPENAI_API_KEY
 
   chat_mod_server("claude", claude)


### PR DESCRIPTION
Before this commit:

1. Call `chat_app(client)` (or `ellmer::live_browser(client)`, which passes through to `chat_app`)
2. Chat with the bot a little bit
3. Hit Reload in the browser window

The discussion you have disappears, but the state is still present in the client--the UI and server state have gotten out of sync.

If you Ctrl+C out of the app, and then call `chat_app(client)` again, the existing messages are now displayed. But if you talk more, and then hit Reload, you'll be reverted back to the UI state that was correct at the time `chat_app(client)` was most recently called.

This is fixed by calling `chat_ui` at page load time, not at `chat_app()` invocation time.

(Note that it's unsafe to use a `chat_app()` from multiple browser windows simultaneously, since every chat will mutate the same client object. Might be worth putting in a tiny bit of code that closes existing sessions when a new session arrives.)