### PR TITLE
Update `chat_enable_bookmarking()` to work with latest `{ellmer}`

### DIFF
--- a/pkg-r/R/client_state.R
+++ b/pkg-r/R/client_state.R
@@ -23,8 +23,7 @@ method(client_get_state, S7::new_S3_class(c("Chat", "R6"))) <-
     # Instead, save only the `turns` information
     recorded_turns <- lapply(
       client$get_turns(),
-      ellmer::contents_record,
-      chat = client
+      ellmer::contents_record
     )
 
     if (is_url_bookmarkstore()) {
@@ -74,8 +73,7 @@ method(client_set_state, S7::new_S3_class(c("Chat", "R6"))) <-
 
     replayed_turns <- lapply(
       recorded_turns,
-      ellmer::contents_replay,
-      chat = client
+      ellmer::contents_replay
     )
 
     client$set_turns(replayed_turns)


### PR DESCRIPTION
If you run this app and submit input, you currently get an error -- I believe because the function signature of these ellmer functions changed.

cc @schloerke 

```r
library(shiny)
library(bslib)
library(shinychat)

ui <- function(request) {
  page_fillable(chat_ui("chat"))
}

server <- function(input, output, session) {
  chat_client <- ellmer::chat_anthropic(
    system_prompt = "Important: Always respond in a limerick",
    echo = TRUE
  )

  chat_enable_bookmarking("chat", chat_client)

  observeEvent(input$chat_user_input, {
    stream <- chat_client$stream_async(input$chat_user_input)
    chat_append("chat", stream)
  })
}

shinyApp(ui, server, enableBookmarking = "server")
```


```
Error in FUN: unused argument (chat = <environment>)
```