### PR TITLE
fix(chat_restore): messages shouldn't be cleared before restoring

### DIFF
--- a/pkg-r/R/chat_restore.R
+++ b/pkg-r/R/chat_restore.R
@@ -127,7 +127,6 @@ chat_restore <- function(
 
       # Set the UI
       shiny::withReactiveDomain(session, {
-        chat_clear(id)
         client_set_ui(client, id = id)
       })
     })


### PR DESCRIPTION
Follow up to #28. 

Currently, when a chat gets restored, the startup messages (i.e., messages in `chat_ui(messages = list(....))`) get dropped. To repro, submit messages in this app, refresh the page, and note that the 1st message gets dropped:

```R
library(shiny)
library(bslib)
library(shinychat)
library(ellmer)

ui <- function(...) {
  page_fillable(
    chat_ui(
      "chat",
      messages = list("A starting message with important user context")
    )
  )
}

server <- function(input, output, session) {
  chat_client <- chat_openai(system_prompt = "Be brief")
  chat_client$set_turns(
    list(
      Turn(role = "user", content = "Foo"),
      Turn(role = "assistant", content = "You said: Foo"),
    )
  )
  chat_restore("chat", chat_client)
  observeEvent(input$chat_user_input, {
    stream <- chat_client$stream_async(input$chat_user_input)
    chat_append("chat", stream)
  })
}

shinyApp(ui, server, enableBookmarking = "url")
```


After this change, they no longer get dropped. 

For context, I think I had overlooked in #28 that this `chat_clear()` call was present. I'm pretty sure it was there because, at one time, we were doing the same in Python (because `ui.Chat(messages=["..."])` would append to UI _and_ state). We have since deprecated that usage for `chat.ui(messages=["..."])` where "undoing" of the duplicate messages is no longer needed -- [here is actually a comment in the Python source where we callout that this isn't needed](https://github.com/posit-dev/shinychat/blob/1e5b7cc008ccf2f69ab5e9aadd178f79f88665cd/pkg-py/src/shinychat/_chat.py#L1568-L1570)