### PR TITLE
feat(pkg-py): Add a `shinychat.types` module

### DIFF
--- a/pkg-py/src/shinychat/types/__init__.py
+++ b/pkg-py/src/shinychat/types/__init__.py
@@ -1,0 +1,5 @@
+from .._chat import ChatMessageDict
+
+__all__ = [
+    "ChatMessageDict",
+]


### PR DESCRIPTION
`py-shiny` will want to re-export `shinychat.types.ChatMessageDict` as `shiny.ui.ChatMessageDict` (`shiny` really needs to move more types into the `shiny.types` module)