### PR TITLE
fix(pkg-py): fix messages input type for express `Chat.ui()` method

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -1603,7 +1603,7 @@ class ChatExpress(Chat):
     def ui(
         self,
         *,
-        messages: Optional[Sequence[str | ChatMessageDict]] = None,
+        messages: Optional[Sequence[TagChild | ChatMessageDict]] = None,
         placeholder: str = "Enter a message...",
         width: CssUnit = "min(680px, 100%)",
         height: CssUnit = "auto",


### PR DESCRIPTION
Brings the `messages` type for `shinychat.express.Chat.ui()` in line with `shinychat.chat_ui()` (which already has the proper type).

Needed to pass type checks in https://github.com/posit-dev/py-shiny/pull/2051