### PR TITLE
fix(pkg-r): If `value` is html, call `as.tags()` to convert it to a tags object

### DIFF
--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -168,6 +168,9 @@ as.tags.shinychat_tool_card <- function(x, ...) {
   if (identical(x$value_type, "html") && !is.character(x$value)) {
     x$value <- as.tags(x$value)
   }
+  if (!is.null(x$icon) && !is.character(x$icon)) {
+    x$icon <- as.tags(x$icon)
+  }
 
   names(x) <- gsub("_", "-", names(x))
 


### PR DESCRIPTION
Small follow-up to #52. When `$value` is HTML in tool results, we need to also call `as.tags()` on `$value`. Same for `$icon`.