### PR TITLE
chore(pkg-py): require directly import `types` and `playwright`

### DIFF
--- a/pkg-py/src/shinychat/__init__.py
+++ b/pkg-py/src/shinychat/__init__.py
@@ -1,4 +1,3 @@
-from . import playwright, types
 from ._chat import Chat, chat_ui
 from ._chat_normalize import message_content, message_content_chunk
 from ._markdown_stream import MarkdownStream, output_markdown_stream
@@ -10,6 +9,4 @@ __all__ = [
     "output_markdown_stream",
     "message_content",
     "message_content_chunk",
-    "types",
-    "playwright",
 ]


### PR DESCRIPTION
Remove `types` and `playwright` from `__init__.py`, requiring that these modules be accessed directly. Otherwise, `shinychat` requires `playwright`.

```py
# instead of this
from shinychat import playwright

# use this
import shinychat.playwright

# but you probably wanted this anyway
from shinychat.playwright import ChatController
```

`shinychat.playwright` was the original culprit, but I think it's reasonable to need to import from `shinychat.types` directly.