### PR TITLE
feat(pkg-r): Update module return value

### DIFF
--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     jsonlite,
     lifecycle,
     promises (>= 1.3.2),
-    rlang,
+    rlang (>= 1.1.0),
     S7,
     shiny (>= 1.10.0)
 Suggests:

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -10,6 +10,8 @@
 
 * Added `chat_append(icon=...)` and `chat_ui(icon_assistant=...)` for customizing the icon that appears next to assistant responses. (#88)
 
+* `chat_mod_server()` now returns a list of reactives for `last_input` and `last_turn`, as well and functions to `update_user_input()` and `clear()` the chat. (#130)
+
 ## Improvements
 
 * `chat_app()` now correctly restores the chat client state when refreshing the app, e.g. by reloading the page. (#71)

--- a/pkg-r/man/chat_app.Rd
+++ b/pkg-r/man/chat_app.Rd
@@ -48,7 +48,18 @@ in \code{\link[=chat_ui]{chat_ui()}}.}
 \item \code{chat_app()} returns a \code{\link[shiny:shinyApp]{shiny::shinyApp()}} object.
 \item \code{chat_mod_ui()} returns the UI for a shinychat module.
 \item \code{chat_mod_server()} includes the shinychat module server logic, and
-and returns the last turn upon successful chat completion.
+and a list with:
+\itemize{
+\item \code{last_input}: A reactive value containing the last user input.
+\item \code{last_turn}: A reactive value containing the last assistant turn.
+\item \code{update_user_input()}: A function to update the chat input or submit a
+new user input. Takes the same arguments as \code{\link[=update_chat_user_input]{update_chat_user_input()}},
+except for \code{id} and \code{session}, which are supplied automatically.
+\item \code{clear()}: A function to clear the chat history and the chat UI.
+Takes a single argument, \code{clear_history}, which indicates whether to
+also clear the chat history in the \code{client} object. Defaults to \code{TRUE}.
+\item \code{client}: The chat client object, which is mutated as you chat.
+}
 }
 }
 \description{


### PR DESCRIPTION
Updates `chat_mod_server()` to return a list of values including:

-  `last_input`: A reactive value containing the last user input.
-  `last_turn`: A reactive value containing the last assistant turn.
-  `update_user_input()`: A function to update the chat input or submit a new user input. Takes the same arguments as [update_chat_user_input()], except for `id` and `session`, which are supplied automatically.
-  `clear()`: A function to clear the chat history and the chat UI. Takes a single argument, `clear_history`, which indicates whether to also clear the chat history in the `client` object. Defaults to `TRUE`.
-  `client`: The chat client object, which is mutated as you chat.


<details><summary>Example app</summary>

```r
library(shiny)
library(bslib)
pkgload::load_all(here::here("pkg-r"))
library(shinychat)

ui <- page_fillable(
  layout_columns(
    fill = FALSE,
    actionButton("update", "Tell me a joke!"),
    actionButton("clear", "Clear chat")
  ),
  layout_columns(
    card(
      card_header("Chat"),
      chat_mod_ui("chat")
    ),
    card(
      card_header("Debug info"),
      verbatimTextOutput("debug")
    )
  )
)

server <- function(input, output, session) {
  chat <- chat_mod_server("chat", ellmer::chat("openai/gpt-4.1-nano"))

  observeEvent(input$update, {
    chat$update_user_input("Tell me a joke!", submit = TRUE)
  })

  observeEvent(input$clear, {
    chat$clear()
  })

  output$debug <- renderPrint({
    list(
      last_turn = chat$last_turn(),
      last_input = chat$last_input()
    )
  })
}

shinyApp(ui, server)
```

</details>