### PR TITLE
feat(pkg-py): Improvements for statically rendered messages

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### New features
 
+* `ChatMessage()` can now be constructed outside of a Shiny session. (#131)
+* `Chat.chat_ui(messages=...)` now supports any type also supported by `message_content()`. (#131)
 
 ## [0.2.0] - 2025-09-10
 

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -1682,7 +1682,9 @@ class ChatExpress(Chat):
 def chat_ui(
     id: str,
     *,
-    messages: Optional[Iterable[Any]] = None,
+    messages: Optional[
+        Iterable[str | TagChild | ChatMessageDict | ChatMessage | Any]
+    ] = None,
     placeholder: str = "Enter a message...",
     width: CssUnit = "min(680px, 100%)",
     height: CssUnit = "auto",

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -20,7 +20,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from htmltools import HTML, Tag, TagAttrValue, TagChild, TagList, css
+from htmltools import HTML, Tag, TagAttrValue, TagChild, TagList, css, HTMLDependency
 from shiny import reactive
 from shiny._deprecated import warn_deprecated
 from shiny.bookmark import BookmarkState, RestoreState
@@ -1580,7 +1580,9 @@ class ChatExpress(Chat):
     def ui(
         self,
         *,
-        messages: Optional[Sequence[TagChild | ChatMessageDict]] = None,
+        messages: Optional[
+            Iterable[str | TagChild | ChatMessageDict | ChatMessage | Any]
+        ] = None,
         placeholder: str = "Enter a message...",
         width: CssUnit = "min(680px, 100%)",
         height: CssUnit = "auto",
@@ -1751,10 +1753,11 @@ def chat_ui(
         messages = []
     for x in messages:
         msg = message_content(x)
+        deps = [HTMLDependency(**d) for d in msg.html_deps]
         message_tags.append(
             Tag(
                 "shiny-chat-message",
-                *msg.html_deps,
+                *deps,
                 content=msg.content,
                 icon=icon_attr,
                 data_role=msg.role,

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -20,15 +20,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from htmltools import (
-    HTML,
-    RenderedHTML,
-    Tag,
-    TagAttrValue,
-    TagChild,
-    TagList,
-    css,
-)
+from htmltools import HTML, Tag, TagAttrValue, TagChild, TagList, css
 from shiny import reactive
 from shiny._deprecated import warn_deprecated
 from shiny.bookmark import BookmarkState, RestoreState
@@ -1690,12 +1682,12 @@ class ChatExpress(Chat):
 def chat_ui(
     id: str,
     *,
-    messages: Optional[Sequence[TagChild | ChatMessageDict]] = None,
+    messages: Optional[Iterable[Any]] = None,
     placeholder: str = "Enter a message...",
     width: CssUnit = "min(680px, 100%)",
     height: CssUnit = "auto",
     fill: bool = True,
-    icon_assistant: HTML | Tag | TagList | None = None,
+    icon_assistant: Optional[HTML | Tag | TagList] = None,
     **kwargs: TagAttrValue,
 ) -> Tag:
     """
@@ -1722,6 +1714,7 @@ def chat_ui(
               interpreted as markdown as long as they're not inside HTML.
         * A dictionary with `content` and `role` keys. The `content` key can contain a
           content as described above, and the `role` key can be "assistant" or "user".
+        * More generally, any type registered with :func:`shinychat.message_content`.
 
         **NOTE:** content may include specially formatted **input suggestion** links
         (see :method:`~shiny.ui.Chat.append_message` for more info).
@@ -1755,34 +1748,14 @@ def chat_ui(
     if messages is None:
         messages = []
     for x in messages:
-        role = "assistant"
-        content: TagChild = None
-        if not isinstance(x, dict):
-            content = x
-        else:
-            if "content" not in x:
-                raise ValueError(
-                    "Each message dictionary must have a 'content' key."
-                )
-
-            content = x["content"]
-            if "role" in x:
-                role = x["role"]
-
-        # `content` is most likely a string, so avoid overhead in that case
-        # (it's also important that we *don't escape HTML* here).
-        if isinstance(content, str):
-            ui: RenderedHTML = {"html": content, "dependencies": []}
-        else:
-            ui = TagList(content).render()
-
+        msg = message_content(x)
         message_tags.append(
             Tag(
                 "shiny-chat-message",
-                ui["dependencies"],
-                content=ui["html"],
+                *msg.html_deps,
+                content=msg.content,
                 icon=icon_attr,
-                data_role=role,
+                data_role=msg.role,
             )
         )
 

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -20,7 +20,15 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from htmltools import HTML, Tag, TagAttrValue, TagChild, TagList, css, HTMLDependency
+from htmltools import (
+    HTML,
+    HTMLDependency,
+    Tag,
+    TagAttrValue,
+    TagChild,
+    TagList,
+    css,
+)
 from shiny import reactive
 from shiny._deprecated import warn_deprecated
 from shiny.bookmark import BookmarkState, RestoreState
@@ -587,6 +595,7 @@ class Chat:
             * A dictionary with `content` and `role` keys. The `content` key can contain
               content as described above, and the `role` key can be "assistant" or
               "user".
+            * More generally, any type registered with :func:`shinychat.message_content`.
 
             **NOTE:** content may include specially formatted **input suggestion** links
             (see note below).
@@ -821,6 +830,7 @@ class Chat:
             * A dictionary with `content` and `role` keys. The `content` key can contain
               content as described above, and the `role` key can be "assistant" or
               "user".
+            * More generally, any type registered with :func:`shinychat.message_content_chunk`.
 
             **NOTE:** content may include specially formatted **input suggestion** links
             (see note below).
@@ -1753,11 +1763,10 @@ def chat_ui(
         messages = []
     for x in messages:
         msg = message_content(x)
-        deps = [HTMLDependency(**d) for d in msg.html_deps]
         message_tags.append(
             Tag(
                 "shiny-chat-message",
-                *deps,
+                *[HTMLDependency(**d) for d in msg.html_deps],
                 content=msg.content,
                 icon=icon_attr,
                 data_role=msg.role,

--- a/pkg-py/src/shinychat/_chat_types.py
+++ b/pkg-py/src/shinychat/_chat_types.py
@@ -32,13 +32,11 @@ class ChatMessage:
         # markdown), so only process it if it's not a string.
         deps = []
         if not isinstance(content, str):
+            res = TagList(content).render()
+            content, deps = res["html"], res["dependencies"]
             session = get_current_session()
             if session:
-                res = session._process_ui(content)
-                content, deps = res["html"], res["deps"]
-            else:
-                res = TagList(content).render()
-                content, deps = res["html"], res["dependencies"]
+                session._process_ui(content)
 
         if is_html:
             # Code blocks with `{=html}` infostrings are rendered as-is by a

--- a/pkg-py/src/shinychat/_chat_types.py
+++ b/pkg-py/src/shinychat/_chat_types.py
@@ -35,13 +35,11 @@ class ChatMessage:
             session = get_current_session()
             if session:
                 res = session._process_ui(content)
-                content, deps = res["html"], res["deps"]
+                deps = res["deps"]
             else:
                 res = TagList(content).render()
-                content, deps = (
-                    res["html"],
-                    [d.as_dict() for d in res["dependencies"]],
-                )
+                deps = [d.as_dict() for d in res["dependencies"]]
+            content = res["html"]
 
         if is_html:
             # Code blocks with `{=html}` infostrings are rendered as-is by a

--- a/pkg-py/src/shinychat/_chat_types.py
+++ b/pkg-py/src/shinychat/_chat_types.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal, TypedDict
 
 from htmltools import HTML, Tag, TagChild, Tagifiable, TagList
-from shiny.session import require_active_session
+from shiny.session import get_current_session
 
 from ._typing_extensions import NotRequired
 
@@ -32,10 +32,13 @@ class ChatMessage:
         # markdown), so only process it if it's not a string.
         deps = []
         if not isinstance(content, str):
-            session = require_active_session(None)
-            res = session._process_ui(content)
-            content = res["html"]
-            deps = res["deps"]
+            session = get_current_session()
+            if session:
+                res = session._process_ui(content)
+                content, deps = res["html"], res["deps"]
+            else:
+                res = TagList(content).render()
+                content, deps = res["html"], res["dependencies"]
 
         if is_html:
             # Code blocks with `{=html}` infostrings are rendered as-is by a

--- a/pkg-py/src/shinychat/_chat_types.py
+++ b/pkg-py/src/shinychat/_chat_types.py
@@ -32,11 +32,16 @@ class ChatMessage:
         # markdown), so only process it if it's not a string.
         deps = []
         if not isinstance(content, str):
-            res = TagList(content).render()
-            content, deps = res["html"], res["dependencies"]
             session = get_current_session()
             if session:
-                session._process_ui(content)
+                res = session._process_ui(content)
+                content, deps = res["html"], res["deps"]
+            else:
+                res = TagList(content).render()
+                content, deps = (
+                    res["html"],
+                    [d.as_dict() for d in res["dependencies"]],
+                )
 
         if is_html:
             # Code blocks with `{=html}` infostrings are rendered as-is by a

--- a/pkg-py/src/shinychat/_chat_types.py
+++ b/pkg-py/src/shinychat/_chat_types.py
@@ -33,7 +33,7 @@ class ChatMessage:
         deps = []
         if not isinstance(content, str):
             session = get_current_session()
-            if session:
+            if session and not session.is_stub_session():
                 res = session._process_ui(content)
                 deps = res["deps"]
             else:

--- a/pkg-py/tests/playwright/chat/basic/app.py
+++ b/pkg-py/tests/playwright/chat/basic/app.py
@@ -5,15 +5,10 @@ from shinychat.express import Chat
 ui.page_opts(title="Hello Chat")
 
 # Create a chat instance, with an initial message
-chat = Chat(
-    id="chat",
-    messages=[
-        {"content": "Hello! How can I help you today?", "role": "assistant"},
-    ],
-)
+chat = Chat(id="chat")
 
 # Display the chat
-chat.ui()
+chat.ui(messages=["Hello! How can I help you today?"])
 
 
 # Define a callback to run when the user submits a message

--- a/pkg-py/tests/playwright/chat/basic/test_chat_basic.py
+++ b/pkg-py/tests/playwright/chat/basic/test_chat_basic.py
@@ -1,7 +1,6 @@
 from playwright.sync_api import Page, expect
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
-
 from shinychat.playwright import ChatController
 
 

--- a/pkg-py/tests/playwright/chat/basic/test_chat_basic.py
+++ b/pkg-py/tests/playwright/chat/basic/test_chat_basic.py
@@ -1,6 +1,7 @@
 from playwright.sync_api import Page, expect
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
+
 from shinychat.playwright import ChatController
 
 
@@ -42,7 +43,6 @@ def test_validate_chat_basic(page: Page, local_app: ShinyAppProc) -> None:
     message_state = controller.OutputCode(page, "message_state")
     message_state_expected = tuple(
         [
-            {"content": initial_message, "role": "assistant"},
             {"content": f"\n{user_message}", "role": "user"},
             {"content": f"You said: \n{user_message}", "role": "assistant"},
             {"content": f"{user_message2}", "role": "user"},

--- a/pkg-py/tests/playwright/chat/icon/app.py
+++ b/pkg-py/tests/playwright/chat/icon/app.py
@@ -11,19 +11,14 @@ app_opts(static_assets={"/img": Path(__file__).parent / "img"})
 
 with ui.layout_columns():
     # Default Bot ---------------------------------------------------------------------
-    chat_default = Chat(
-        id="chat_default",
-        messages=[
-            {
-                "content": "Hello! I'm Default Bot. How can I help you today?",
-                "role": "assistant",
-            },
-        ],
-    )
+    chat_default = Chat(id="chat_default")
 
     with ui.div():
         ui.h2("Default Bot")
-        chat_default.ui(icon_assistant=None)
+        chat_default.ui(
+            messages=["Hello! I'm Default Bot. How can I help you today?"],
+            icon_assistant=None,
+        )
 
     @chat_default.on_user_submit
     async def handle_user_input_default(user_input: str):

--- a/pkg-py/tests/playwright/chat/input-suggestion/app.py
+++ b/pkg-py/tests/playwright/chat/input-suggestion/app.py
@@ -12,9 +12,9 @@ suggestion2 = """
 And <span id="fifth" data-suggestion="another suggestion" data-suggestion-submit="true">this suggestion will also auto-submit</span>.</p>
 """
 
-chat = Chat("chat", messages=[suggestion2])
+chat = Chat("chat")
 
-chat.ui(messages=[suggestions1])
+chat.ui(messages=[suggestions1, suggestion2])
 
 
 @chat.on_user_submit

--- a/pkg-py/tests/playwright/chat/shiny_input/app.py
+++ b/pkg-py/tests/playwright/chat/shiny_input/app.py
@@ -1,6 +1,5 @@
 from shiny import reactive
 from shiny.express import input, ui
-
 from shinychat.express import Chat
 
 ui.page_opts(title="Testing input bindings in Chat", gap="3rem")

--- a/pkg-py/tests/playwright/chat/shiny_input/app.py
+++ b/pkg-py/tests/playwright/chat/shiny_input/app.py
@@ -1,5 +1,6 @@
 from shiny import reactive
 from shiny.express import input, ui
+
 from shinychat.express import Chat
 
 ui.page_opts(title="Testing input bindings in Chat", gap="3rem")

--- a/pkg-py/tests/playwright/chat/shiny_input/app.py
+++ b/pkg-py/tests/playwright/chat/shiny_input/app.py
@@ -19,11 +19,11 @@ welcome = ui.TagList(
     ),
 )
 
-chat = Chat(
-    id="chat",
+chat = Chat(id="chat")
+chat.ui(
     messages=[welcome],
+    class_="mb-5",
 )
-chat.ui(class_="mb-5")
 
 
 @reactive.effect

--- a/pkg-py/tests/playwright/chat/shiny_output/app.py
+++ b/pkg-py/tests/playwright/chat/shiny_output/app.py
@@ -18,11 +18,12 @@ with ui.hold() as map_ui:
         return ipyl.Map(center=(52, 10), zoom=8)
 
 
-chat = ui.Chat(id="chat")
-
-chat.ui(
+chat = ui.Chat(
+    id="chat",
     messages=[map_ui],
 )
+
+chat.ui()
 
 with ui.hold() as df_1:
 

--- a/pkg-py/tests/playwright/chat/shiny_output/app.py
+++ b/pkg-py/tests/playwright/chat/shiny_output/app.py
@@ -18,12 +18,11 @@ with ui.hold() as map_ui:
         return ipyl.Map(center=(52, 10), zoom=8)
 
 
-chat = ui.Chat(
-    id="chat",
+chat = ui.Chat(id="chat")
+
+chat.ui(
     messages=[map_ui],
 )
-
-chat.ui()
 
 with ui.hold() as df_1:
 


### PR DESCRIPTION
This PR adds 2 things:

1. `Chat.chat_ui(messages=...)` now supports any type also supported by `message_content()`
2. `ChatMessage()` can now be constructed outside of a Shiny session