### PR TITLE
fix(url): Update source code link in Quarto config

### DIFF
--- a/pkg-py/docs/_quarto.yml
+++ b/pkg-py/docs/_quarto.yml
@@ -34,7 +34,7 @@ website:
       - icon: github
         menu:
           - text: Source code
-            href:  https://github.com/posit-dev/shinychat/pkg-py
+            href:  https://github.com/posit-dev/shinychat/tree/main/pkg-py
           - text: Report a bug
             href:  https://github.com/posit-dev/shinychat/issues/new
 


### PR DESCRIPTION
Changed the GitHub source code link in _quarto.yml to point directly to the pkg-py directory in the repository for improved navigation.

Current behavior:

![bug-url](https://github.com/user-attachments/assets/eb42130f-82a3-4e0d-b819-e0dc9077eec0)
