### PR TITLE
feat(chat_mod_server): Add `$append()` function

### DIFF
--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -81,6 +81,9 @@
 #'     * `update_user_input()`: A function to update the chat input or submit a
 #'       new user input. Takes the same arguments as [update_chat_user_input()],
 #'       except for `id` and `session`, which are supplied automatically.
+#'     * `append()`: A function to append a new message to the chat UI. Takes
+#'       the same arguments as [chat_append()], except for `id` and `session`,
+#'       which are supplied automatically.
 #'     * `clear()`: A function to clear the chat history and the chat UI.
 #'       `clear()` takes an optional list of `messages` used to initialize the
 #'       chat after clearing. `messages` should be a list of messages, where
@@ -224,6 +227,10 @@ chat_mod_server <- function(
       )
     }
 
+    chat_append_mod <- function(response, role = "assistant", icon = NULL) {
+      chat_append("chat", response, role = role, icon = icon, session = session)
+    }
+
     client_clear <- function(
       messages = NULL,
       client_history = c("clear", "set", "append", "keep")
@@ -271,6 +278,7 @@ chat_mod_server <- function(
       last_turn = shiny::reactive(last_turn()),
       last_input = shiny::reactive(last_input()),
       client = client,
+      append = chat_append_mod,
       update_user_input = chat_update_user_input,
       clear = client_clear
     )

--- a/pkg-r/man/chat_app.Rd
+++ b/pkg-r/man/chat_app.Rd
@@ -55,6 +55,9 @@ and a list with:
 \item \code{update_user_input()}: A function to update the chat input or submit a
 new user input. Takes the same arguments as \code{\link[=update_chat_user_input]{update_chat_user_input()}},
 except for \code{id} and \code{session}, which are supplied automatically.
+\item \code{append()}: A function to append a new message to the chat UI. Takes
+the same arguments as \code{\link[=chat_append]{chat_append()}}, except for \code{id} and \code{session},
+which are supplied automatically.
 \item \code{clear()}: A function to clear the chat history and the chat UI.
 \code{clear()} takes an optional list of \code{messages} used to initialize the
 chat after clearing. \code{messages} should be a list of messages, where


### PR DESCRIPTION
Adds `$append()` to the functions returned by `chat_mod_server()` to make it easier to extend a chat UI module. The implementation simply wraps `chat_append()` with `id` and `session` provided.

Closes #140