### PR TITLE
address `contents_shinychat()` error with tool results

### DIFF
--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -384,7 +384,11 @@ S7::method(contents_shinychat, S7::new_S3_class(c("Chat", "R6"))) <- function(
 
     # Turns containing only tool results are converted into assistant turns
     if (every(turn@contents, S7::S7_inherits, ellmer::ContentToolResult)) {
-      turn@role <- "assistant"
+      if (packageVersion("ellmer") >= "0.3.2.9000") {
+        turn <- ellmer::AssistantTurn(turn@contents)
+      } else {
+        turn@role <- "assistant"
+      }
       return(turn)
     }
 


### PR DESCRIPTION
Closes #153. With dev ellmer and this PR:

``` r
library(ellmer)
library(shinychat)

chat <- chat_openai()
#> Using model = "gpt-4.1".

chat$register_tool(
  tool(getwd, description = "Get the current working directory")
)

chat$chat("What is the current working directory?")
#> ◯ [tool call] getwd()
#> ● #> /private/var/folders/vf/8ns_0t1s66b_m36bwyhdgd2r0000gp/T/RtmpGRTbM9/repre…
#> The current working directory is:
#> /private/var/folders/vf/8ns_0t1s66b_m36bwyhdgd2r0000gp/T/RtmpGRTbM9/reprex-665d1b3fdb7b-beton-pug

contents_shinychat(chat)
#> [[1]]
#> [[1]]$role
#> [1] "user"
#> 
#> [[1]]$content
#> [1] "What is the current working directory?"
#> 
#> 
#> [[2]]
#> [[2]]$role
#> [1] "assistant"
#> 
#> [[2]]$content
#> [[2]]$content[[1]]
#> <shiny-tool-result request-id="fc_04c93ccdb27578e501691606bc0eb88196a4227dbff74c8043" tool-name="getwd" request-call="getwd()" status="success" show-request value="/private/var/folders/vf/8ns_0t1s66b_m36bwyhdgd2r0000gp/T/RtmpGRTbM9/reprex-665d1b3fdb7b-beton-pug" value-type="code"></shiny-tool-result>
#> 
#> [[2]]$content[[2]]
#> [1] "The current working directory is:\n/private/var/folders/vf/8ns_0t1s66b_m36bwyhdgd2r0000gp/T/RtmpGRTbM9/reprex-665d1b3fdb7b-beton-pug"
```

<sup>Created on 2025-11-13 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>