### PR TITLE
fix(pkg-py): add __all__ exports for pyright 1.1.409 compat

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -33,7 +33,7 @@ from ._chat_bookmark import (
 )
 from ._chat_normalize import message_content, message_content_chunk
 from ._chat_provider_types import (
-    AnthropicMessage,  # pyright: ignore[reportAttributeAccessIssue]
+    AnthropicMessage,
     GoogleMessage,
     LangChainMessage,
     OllamaMessage,
@@ -74,6 +74,7 @@ else:
 __all__ = (
     "Chat",
     "ChatExpress",
+    "ChatMessage",
     "chat_ui",
     "ChatMessageDict",
 )

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -33,7 +33,7 @@ from ._chat_bookmark import (
 )
 from ._chat_normalize import message_content, message_content_chunk
 from ._chat_provider_types import (
-    AnthropicMessage,
+    AnthropicMessage,  # pyright: ignore[reportAttributeAccessIssue]
     GoogleMessage,
     LangChainMessage,
     OllamaMessage,

--- a/pkg-py/src/shinychat/_chat_provider_types.py
+++ b/pkg-py/src/shinychat/_chat_provider_types.py
@@ -3,6 +3,17 @@ from typing import TYPE_CHECKING, Literal, Union
 
 from ._chat_types import ChatMessageDict
 
+__all__ = (
+    "AnthropicMessage",
+    "GoogleMessage",
+    "LangChainMessage",
+    "OllamaMessage",
+    "OpenAIMessage",
+    "ProviderMessage",
+    "ProviderMessageFormat",
+    "as_provider_message",
+)
+
 if TYPE_CHECKING:
     from anthropic.types import (  # pyright: ignore[reportMissingImports]
         MessageParam as AnthropicMessage,


### PR DESCRIPTION
## Summary

Pyright 1.1.409 (released today) started enforcing `reportPrivateImportUsage` for imports from underscore-prefixed modules that lack `__all__`. This breaks CI on main and all open branches.

- Add `__all__` to `_chat_provider_types.py` so `AnthropicMessage`, `OllamaMessage`, etc. are recognized as public exports
- Add `ChatMessage` to `_chat.py`'s `__all__` so `types/__init__.py` can re-export it
- Remove now-unnecessary `pyright: ignore[reportAttributeAccessIssue]` comment

## Test plan

- [x] `pyright` passes locally with 1.1.409 (`PYRIGHT_PYTHON_FORCE_VERSION=1.1.409 uv run pyright`)
- [ ] CI green