### PR TITLE
fix: Route initial MarkdownStream content through split_html_islands

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* Fixed Shiny input bindings inside `MarkdownStream`'s initial `content` failing to bind on WebKit. The `content` parameter now routes non-string content through `split_html_islands()`, consistent with how streamed content is already handled. (#205)
+* Fixed an issue where Shiny UI components (e.g., inputs) passed to `MarkdownStream`'s `content` parameter could fail to initialize, especially on WebKit-based browsers. (#205)
 
 ## [0.3.0] - 2026-04-29
 

--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-04-30
+
+### Bug fixes
+
+* Fixed Shiny input bindings inside `MarkdownStream`'s initial `content` failing to bind on WebKit. The `content` parameter now routes non-string content through `split_html_islands()`, consistent with how streamed content is already handled. (#205)
+
 ## [0.3.0] - 2026-04-29
 
 ### Experimental internal changes

--- a/pkg-py/src/shinychat/_markdown_stream.py
+++ b/pkg-py/src/shinychat/_markdown_stream.py
@@ -364,7 +364,7 @@ def output_markdown_stream(
     if isinstance(content, str):
         ui: RenderedHTML = {"html": content, "dependencies": []}
     else:
-        ui = TagList(content).render()
+        ui = TagList(*split_html_islands(content)).render()
 
     return Tag(
         "shiny-markdown-stream",

--- a/pkg-r/R/chat.R
+++ b/pkg-r/R/chat.R
@@ -97,7 +97,9 @@ chat_ui <- function(
     if (is.character(content)) {
       ui <- list(html = paste(content, collapse = "\n"))
     } else {
-      ui <- with_current_theme(htmltools::renderTags(pre_process_ui(content)))
+      ui <- with_current_theme({
+        htmltools::renderTags(pre_process_ui(content))
+      })
     }
 
     tag(

--- a/pkg-r/R/markdown-stream.R
+++ b/pkg-r/R/markdown-stream.R
@@ -40,7 +40,7 @@ output_markdown_stream <- function(
   if (is.character(content)) {
     ui <- list(html = paste(content, collapse = "\n"))
   } else {
-    ui <- with_current_theme(htmltools::renderTags(content))
+    ui <- with_current_theme(htmltools::renderTags(pre_process_ui(content)))
   }
 
   htmltools::tag(

--- a/pkg-r/R/markdown-stream.R
+++ b/pkg-r/R/markdown-stream.R
@@ -40,7 +40,9 @@ output_markdown_stream <- function(
   if (is.character(content)) {
     ui <- list(html = paste(content, collapse = "\n"))
   } else {
-    ui <- with_current_theme(htmltools::renderTags(pre_process_ui(content)))
+    ui <- with_current_theme({
+      htmltools::renderTags(pre_process_ui(content))
+  })
   }
 
   htmltools::tag(

--- a/pkg-r/tests/testthat/_snaps/markdown-stream.md
+++ b/pkg-r/tests/testthat/_snaps/markdown-stream.md
@@ -22,6 +22,6 @@
       [{"name":"foo","all_files":true},{"name":"shinychat","script":{"src":"shinychat.js","type":"module"},"stylesheet":"shinychat.css","all_files":true}] 
       
       $html
-      <shiny-markdown-stream id="stream" style="width:min(680px, 100%);height:auto;margin:0 auto;" content="&lt;div&gt;Hello&lt;/div&gt;" content-type="markdown" auto-scroll=""></shiny-markdown-stream>
+      <shiny-markdown-stream id="stream" style="width:min(680px, 100%);height:auto;margin:0 auto;" content="&lt;shinychat-raw-html&gt;&#10;  &lt;div&gt;Hello&lt;/div&gt;&#10;&lt;/shinychat-raw-html&gt;" content-type="markdown" auto-scroll=""></shiny-markdown-stream>
       
 


### PR DESCRIPTION
## Problem

Shiny inputs statically rendered inside a `MarkdownStream` via the `content` parameter fail to bind on WebKit. This manifests as intermittent failures locally on macOS WebKit, and consistent failures on Linux WebKit in CI (e.g., [py-shiny CI](https://github.com/posit-dev/py-shiny/actions/runs/25193401318)).

### Reproducer (Python)

```python
from shiny import reactive
from shiny.express import input, render, ui

md_stream = ui.MarkdownStream("stream")
md_stream.ui(
    content=ui.TagList(
        "**Hello! Here are a couple inputs:**",
        ui.div(
            ui.input_select("select", "", choices=["a", "b", "c"]),
            ui.input_switch("toggle", "Toggle"),
        ),
    )
)

@render.code
def input_vals():
    return f"Selected: {input.select()} Toggled: {input.toggle()}"
```

On Chromium/Firefox, the inputs bind and work. On WebKit, they appear in the DOM but never receive the `shiny-bound-input` class — the select and switch don't communicate with the server.

## Root cause

When `output_markdown_stream()` receives a `TagChild` as `content`, it renders the HTML directly:

```python
ui = TagList(content).render()
```

This raw HTML is set as the `content` attribute of the `<shiny-markdown-stream>` custom element. On the client, the `connectedCallback` calls `createRoot(this).render(...)` — but React 18's `createRoot().render()` is **not synchronous**; the render is scheduled, not immediate.

The only thing that binds these inputs is Shiny's initial page-level `bindAll(document.documentElement)`. Whether binding succeeds depends on whether React has flushed the render into the DOM by the time that sweep runs. On Chromium/Firefox, React typically wins the race. On WebKit (JavaScriptCore), the render is deferred more often, so `bindAll` sweeps an empty custom element and nothing ever re-binds the inputs.

In contrast, the **streaming** path already calls `split_html_islands()` on non-string content, which wraps Shiny HTML in `<shinychat-raw-html>` tags. These route through the `RawHTML` React component, which explicitly calls `shiny.bindAll(el)` in its `useEffect`. The `content` attribute path was the only one that skipped this pipeline.

## Fix

Route the `content` parameter through `split_html_islands()` before rendering, exactly like the streaming path already does. This is a one-line change in each package:

**Python:**
```diff
-        ui = TagList(content).render()
+        ui = TagList(*split_html_islands(content)).render()
```

**R:**
```diff
-    ui <- with_current_theme(htmltools::renderTags(content))
+    ui <- with_current_theme(htmltools::renderTags(pre_process_ui(content)))
```

## Test plan

- [x] All 63 shinychat tests pass (`uv run pytest pkg-py/tests/ -v`)
- [x] All 9 py-shiny MarkdownStream tests pass across Chromium, Firefox, and WebKit
- [x] The previously failing WebKit test (`test_validate_stream_shiny_ui`) passes 10/10 times locally
- [ ] R package: `devtools::test()` / `R CMD check`