### PR TITLE
chore(pkg-r): apply air formatting

### DIFF
--- a/pkg-r/R/chat_restore.R
+++ b/pkg-r/R/chat_restore.R
@@ -194,7 +194,6 @@ chat_restore <- function(
   invisible(NULL)
 }
 
-
 # Method currently hooked into `chat_append_stream()` and `markdown_stream()`
 # When the incoming stream ends, possibly update the URL given the `id`
 chat_update_bookmark <- function(
@@ -218,7 +217,6 @@ chat_update_bookmark <- function(
   return(prom)
 }
 
-
 # These methods exist to set flags within the session.
 # These flags will determine if the session should be bookmarked when a response has completed.
 # `chat_update_bookmark()` will check if the flag is set and update the URL if it is.
@@ -236,7 +234,6 @@ set_session_bookmark_on_response <- function(session, id, enable) {
     value = if (enable) TRUE else NULL
   )
 }
-
 
 has_session_chat_bookmark_info <- function(session, id) {
   return(!is.null(get_session_chat_bookmark_info(session, id)))

--- a/pkg-r/R/client_state.R
+++ b/pkg-r/R/client_state.R
@@ -80,7 +80,6 @@ method(client_set_state, S7::new_S3_class(c("Chat", "R6"))) <-
     client$set_turns(replayed_turns)
   }
 
-
 method(client_set_ui, S7::new_S3_class(c("Chat", "R6"))) <-
   function(client, ..., id) {
     # TODO-future: Disable bookmarking when restoring. Leverage `tryCatch(finally={})`
@@ -103,7 +102,6 @@ method(client_set_ui, S7::new_S3_class(c("Chat", "R6"))) <-
       }
     })
   }
-
 
 # Used to avoid R CMD check NOTE about unused imports
 `_ignore` <- function() {

--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -309,7 +309,14 @@ get_tool_result_display <- function(content) {
 
   # fmt: skip
   expected_fields <- c(
-    "html", "markdown", "text", "show_request", "open", "full_screen", "title", "icon",
+    "html",
+    "markdown",
+    "text",
+    "show_request",
+    "open",
+    "full_screen",
+    "title",
+    "icon",
     "footer"
   )
 

--- a/pkg-r/R/markdown-stream.R
+++ b/pkg-r/R/markdown-stream.R
@@ -42,7 +42,7 @@ output_markdown_stream <- function(
   } else {
     ui <- with_current_theme({
       htmltools::renderTags(pre_process_ui(content))
-  })
+    })
   }
 
   htmltools::tag(
@@ -157,7 +157,6 @@ markdown_stream <- function(
   # chooses not to do anything with it).
   result
 }
-
 
 markdown_stream_impl <- NULL
 rlang::on_load(

--- a/pkg-r/R/utils.R
+++ b/pkg-r/R/utils.R
@@ -1,7 +1,7 @@
 sanitized_chat_error <- function(err) {
   needs_sanitized <-
     isTRUE(getOption("shiny.sanitize.errors")) &&
-    !inherits(err, "shiny.custom.error")
+      !inherits(err, "shiny.custom.error")
 
   if (needs_sanitized) {
     "\n\n**An error occurred.** Please try again or contact the app author."
@@ -18,7 +18,6 @@ strip_ansi <- function(text) {
   ansi_pattern <- "(\x1B|\x033)\\[[0-9;?=<>]*[@-~]"
   gsub(ansi_pattern, "", text)
 }
-
 
 shinychat_deps <- function() {
   htmltools::htmlDependency(

--- a/pkg-r/R/utils.R
+++ b/pkg-r/R/utils.R
@@ -1,7 +1,7 @@
 sanitized_chat_error <- function(err) {
   needs_sanitized <-
     isTRUE(getOption("shiny.sanitize.errors")) &&
-      !inherits(err, "shiny.custom.error")
+    !inherits(err, "shiny.custom.error")
 
   if (needs_sanitized) {
     "\n\n**An error occurred.** Please try again or contact the app author."

--- a/pkg-r/tests/testthat/apps/tool-basic/app.R
+++ b/pkg-r/tests/testthat/apps/tool-basic/app.R
@@ -16,16 +16,18 @@ TOOL_OPTS <- list(
 ui <- bslib::page_fillable(
   shinychat::chat_mod_ui(
     "chat",
-    messages = list(list(
-      role = "assistant",
-      content = htmltools::HTML(
-        '<span class="suggestion submit">In three separate but parallel tool calls list the files in apps, data, docs</span>
+    messages = list(
+      list(
+        role = "assistant",
+        content = htmltools::HTML(
+          '<span class="suggestion submit">In three separate but parallel tool calls list the files in apps, data, docs</span>
 
 <span class="suggestion submit">Write some basic R code that demonstrates how to use the tidyverse.</span>
 
 <span class="suggestion submit">Brainstorm 10 ideas for a name for a package that creates interactive sparklines in tables.</span>'
+        )
       )
-    ))
+    )
   ),
   actionButton("click", "Click me")
 )

--- a/pkg-r/tests/testthat/test-contents_shinychat.R
+++ b/pkg-r/tests/testthat/test-contents_shinychat.R
@@ -387,14 +387,16 @@ test_that("consolidates adjacent turn types in a Chat object", {
   withr::local_options(OPENAI_API_KEY = "boop")
   chat <- ellmer::chat_openai()
 
-  chat$set_turns(list(
-    ellmer::AssistantTurn(
-      contents = list(ellmer::ContentText("Hello"))
-    ),
-    ellmer::AssistantTurn(
-      contents = list(ellmer::ContentText("World"))
+  chat$set_turns(
+    list(
+      ellmer::AssistantTurn(
+        contents = list(ellmer::ContentText("Hello"))
+      ),
+      ellmer::AssistantTurn(
+        contents = list(ellmer::ContentText("World"))
+      )
     )
-  ))
+  )
 
   messages <- contents_shinychat(chat)
   expect_length(messages, 1)
@@ -406,14 +408,16 @@ test_that("doesn't consolidate adjacent turns with different roles in a Chat obj
   withr::local_options(OPENAI_API_KEY = "boop")
   chat <- ellmer::chat_openai()
 
-  chat$set_turns(list(
-    ellmer::UserTurn(
-      contents = list(ellmer::ContentText("Question"))
-    ),
-    ellmer::AssistantTurn(
-      contents = list(ellmer::ContentText("Answer"))
+  chat$set_turns(
+    list(
+      ellmer::UserTurn(
+        contents = list(ellmer::ContentText("Question"))
+      ),
+      ellmer::AssistantTurn(
+        contents = list(ellmer::ContentText("Answer"))
+      )
     )
-  ))
+  )
 
   messages <- contents_shinychat(chat)
   expect_length(messages, 2) # Previous consolidated message + 2 new messages
@@ -425,19 +429,21 @@ test_that("drops requests and moves results to assistant turn role in a Chat obj
   withr::local_options(OPENAI_API_KEY = "boop")
   chat <- ellmer::chat_openai()
 
-  chat$set_turns(list(
-    ellmer::AssistantTurn(
-      contents = list(
-        ellmer::ContentText("Hello"),
-        new_tool_request()
-      )
-    ),
-    ellmer::UserTurn(
-      contents = list(
-        new_tool_result(value = "success")
+  chat$set_turns(
+    list(
+      ellmer::AssistantTurn(
+        contents = list(
+          ellmer::ContentText("Hello"),
+          new_tool_request()
+        )
+      ),
+      ellmer::UserTurn(
+        contents = list(
+          new_tool_result(value = "success")
+        )
       )
     )
-  ))
+  )
 
   messages <- contents_shinychat(chat)
   expect_length(messages, 1)


### PR DESCRIPTION
## Summary
- Applies `air format` to 7 R files that were causing the R-CMD-check CI failure on main.

## Test plan
- CI should pass (the `routine` job in R-CMD-check was the only failure).