### PR TITLE
Use ContentThinkingDelta for streaming thinking

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -132,8 +132,7 @@ PendingMessage = Tuple[
 ]
 
 
-def _is_content_thinking_delta(msg: Any) -> bool:
-    """Check if a message is a ContentThinkingDelta object from chatlas."""
+def is_content_thinking_delta(msg: object) -> "TypeGuard[chatlas.ContentThinkingDelta]":
     try:
         from chatlas.types import (
             ContentThinkingDelta,  # pyright: ignore[reportAttributeAccessIssue]
@@ -969,7 +968,7 @@ class Chat:
 
         try:
             async for msg in message:
-                if _is_content_thinking_delta(msg):
+                if is_content_thinking_delta(msg):
                     thinking_text: str = msg.thinking
                     thinking_msg = ChatMessage(content=thinking_text, role="assistant")
                     await self._send_append_message(

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -132,14 +132,14 @@ PendingMessage = Tuple[
 ]
 
 
-def _is_content_thinking(msg: Any) -> bool:
-    """Check if a message is a ContentThinking object from chatlas."""
+def _is_content_thinking_delta(msg: Any) -> bool:
+    """Check if a message is a ContentThinkingDelta object from chatlas."""
     try:
         from chatlas.types import (
-            ContentThinking,  # pyright: ignore[reportAttributeAccessIssue]
+            ContentThinkingDelta,  # pyright: ignore[reportAttributeAccessIssue]
         )
 
-        return isinstance(msg, ContentThinking)
+        return isinstance(msg, ContentThinkingDelta)
     except ImportError:
         return False
 
@@ -291,7 +291,6 @@ class Chat:
 
         # Chunked messages get accumulated (using this property) before changing state
         self._current_stream_message: str = ""
-        self._current_stream_thinking: str = ""
         self._current_stream_deps: list[HTMLDependency] = []
         self._current_stream_id: str | None = None
         self._pending_messages: list[PendingMessage] = []
@@ -829,7 +828,6 @@ class Chat:
             if chunk == "end":
                 self._current_stream_id = None
                 self._current_stream_message = ""
-                self._current_stream_thinking = ""
                 self._current_stream_deps = []
                 self._message_stream_checkpoint = ""
                 self._message_stream_deps_checkpoint = []
@@ -971,27 +969,24 @@ class Chat:
 
         try:
             async for msg in message:
-                if _is_content_thinking(msg):
-                    thinking_text = msg.thinking if hasattr(msg, "thinking") else str(msg)
-                    self._current_stream_thinking += thinking_text
+                if _is_content_thinking_delta(msg):
+                    thinking_text: str = msg.thinking
                     thinking_msg = ChatMessage(content=thinking_text, role="assistant")
                     await self._send_append_message(
                         thinking_msg,
                         chunk=True,
                         content_type_override="thinking",
                     )
+                    if msg.phase == "start":
+                        self._current_stream_message += "<thinking>\n"
+                    self._current_stream_message += thinking_text
+                    if msg.phase == "end":
+                        self._current_stream_message += "\n</thinking>\n\n"
                     continue
 
                 await self._append_message_chunk(msg, chunk=True, stream_id=id)
             return self._current_stream_message
         finally:
-            if self._current_stream_thinking:
-                self._current_stream_message = (
-                    "<thinking>\n"
-                    + self._current_stream_thinking
-                    + "\n</thinking>\n\n"
-                    + self._current_stream_message
-                )
             await self._append_message_chunk(empty, chunk="end", stream_id=id)
             await self._flush_pending_messages()
 

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -969,16 +969,14 @@ class Chat:
         try:
             async for msg in message:
                 if is_content_thinking_delta(msg):
-                    thinking_text: str = msg.thinking
-                    thinking_msg = ChatMessage(content=thinking_text, role="assistant")
                     await self._send_append_message(
-                        thinking_msg,
+                        ChatMessage(content=msg.thinking, role="assistant"),
                         chunk=True,
                         content_type_override="thinking",
                     )
                     if msg.phase == "start":
                         self._current_stream_message += "<thinking>\n"
-                    self._current_stream_message += thinking_text
+                    self._current_stream_message += msg.thinking
                     if msg.phase == "end":
                         self._current_stream_message += "\n</thinking>\n\n"
                     continue

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -128,19 +128,7 @@ PendingMessage = Tuple[
     ChunkOption,
     Literal["append", "replace"],
     Union[str, None],
-    "Union[ContentType, None]",
 ]
-
-
-def is_content_thinking_delta(msg: object) -> "TypeGuard[chatlas.ContentThinkingDelta]":
-    try:
-        from chatlas.types import (
-            ContentThinkingDelta,  # pyright: ignore[reportAttributeAccessIssue]
-        )
-
-        return isinstance(msg, ContentThinkingDelta)
-    except ImportError:
-        return False
 
 
 class Chat:
@@ -642,7 +630,7 @@ class Chat:
         """
         # If we're in a stream, queue the message
         if self._current_stream_id:
-            self._pending_messages.append((message, False, "append", None, None))
+            self._pending_messages.append((message, False, "append", None))
             return
 
         msg = message_content(message)
@@ -652,6 +640,7 @@ class Chat:
         self._store_message(msg)
         await self._send_append_message(
             message=msg,
+            content_type=resolve_content_type(message, msg.content),
             chunk=False,
             icon=icon,
         )
@@ -754,12 +743,11 @@ class Chat:
         stream_id: str,
         operation: Literal["append", "replace"] = "append",
         icon: HTML | Tag | TagList | None = None,
-        content_type_override: "ContentType | None" = None,
     ) -> None:
         # If currently we're in a *different* stream, queue the message chunk
         if self._current_stream_id and self._current_stream_id != stream_id:
             self._pending_messages.append(
-                (message, chunk, operation, stream_id, content_type_override)
+                (message, chunk, operation, stream_id)
             )
             return
 
@@ -818,10 +806,10 @@ class Chat:
             # Send the message to the client
             await self._send_append_message(
                 message=msg,
+                content_type=resolve_content_type(message, msg.content),
                 chunk=chunk,
                 operation=operation,
                 icon=icon,
-                content_type_override=content_type_override,
             )
         finally:
             if chunk == "end":
@@ -968,19 +956,6 @@ class Chat:
 
         try:
             async for msg in message:
-                if is_content_thinking_delta(msg):
-                    await self._send_append_message(
-                        ChatMessage(content=msg.thinking, role="assistant"),
-                        chunk=True,
-                        content_type_override="thinking",
-                    )
-                    if msg.phase == "start":
-                        self._current_stream_message += "<thinking>\n"
-                    self._current_stream_message += msg.thinking
-                    if msg.phase == "end":
-                        self._current_stream_message += "\n</thinking>\n\n"
-                    continue
-
                 await self._append_message_chunk(msg, chunk=True, stream_id=id)
             return self._current_stream_message
         finally:
@@ -990,7 +965,7 @@ class Chat:
     async def _flush_pending_messages(self):
         pending = self._pending_messages
         self._pending_messages = []
-        for msg, chunk, operation, stream_id, content_type_override in pending:
+        for msg, chunk, operation, stream_id in pending:
             if chunk is False:
                 await self.append_message(msg)
             else:
@@ -999,17 +974,16 @@ class Chat:
                     chunk=chunk,
                     operation=operation,
                     stream_id=cast(str, stream_id),
-                    content_type_override=content_type_override,
                 )
 
     # Send a message to the UI
     async def _send_append_message(
         self,
         message: StoredMessage | ChatMessage,
+        content_type: "ContentType",
         chunk: ChunkOption = False,
         operation: Literal["append", "replace"] = "append",
         icon: HTML | Tag | TagList | None = None,
-        content_type_override: "ContentType | None" = None,
     ):
         message = self._as_stored_message(message)
 
@@ -1018,11 +992,6 @@ class Chat:
             return
 
         content = message.content
-        content_type: ContentType = (
-            content_type_override
-            if content_type_override is not None
-            else "html" if isinstance(content, HTML) else "markdown"
-        )
 
         msg_payload: MessagePayload = {
             "role": message.role,
@@ -1643,7 +1612,12 @@ class Chat:
                     html_deps=message_dict.get("html_deps"),
                 )
                 self._store_message(stored)
-                await self._send_append_message(stored)
+                await self._send_append_message(
+                    stored,
+                    content_type=resolve_content_type(
+                        message_dict, stored.content
+                    ),
+                )
 
         def _cancel_bookmarking():
             _on_bookmark_client()
@@ -1924,6 +1898,24 @@ def is_tool_result(val: object) -> "TypeGuard[chatlas.ContentToolResult]":
         return isinstance(val, ContentToolResult)
     except ImportError:
         return False
+
+
+def is_content_thinking(msg: object) -> bool:
+    try:
+        from chatlas.types import (
+            ContentThinking,  # pyright: ignore[reportAttributeAccessIssue]
+            ContentThinkingDelta,  # pyright: ignore[reportAttributeAccessIssue]
+        )
+
+        return isinstance(msg, (ContentThinking, ContentThinkingDelta))
+    except ImportError:
+        return False
+
+
+def resolve_content_type(message: object, content: object) -> "ContentType":
+    if is_content_thinking(message):
+        return "thinking"
+    return "html" if isinstance(content, HTML) else "markdown"
 
 
 CHAT_INSTANCES: WeakValueDictionary[str, Chat] = WeakValueDictionary()

--- a/pkg-py/src/shinychat/_chat_normalize.py
+++ b/pkg-py/src/shinychat/_chat_normalize.py
@@ -166,12 +166,22 @@ try:
     def _(chunk: ContentToolResult):
         return message_content(chunk)
 
+    # ContentThinking appears in non-streaming contexts (e.g., bookmark restore).
     # ContentThinkingDelta is handled directly in _append_message_stream,
     # but register it here so message_content_chunk doesn't raise for it.
     try:
         from chatlas.types import (
+            ContentThinking,  # pyright: ignore[reportAttributeAccessIssue]
             ContentThinkingDelta,  # pyright: ignore[reportAttributeAccessIssue]
         )
+
+        @message_content.register
+        def _(message: ContentThinking):
+            return ChatMessage(content=message.thinking)
+
+        @message_content_chunk.register
+        def _(chunk: ContentThinking):
+            return ChatMessage(content=chunk.thinking)
 
         @message_content.register
         def _(message: ContentThinkingDelta):

--- a/pkg-py/src/shinychat/_chat_normalize.py
+++ b/pkg-py/src/shinychat/_chat_normalize.py
@@ -166,19 +166,19 @@ try:
     def _(chunk: ContentToolResult):
         return message_content(chunk)
 
-    # ContentThinking is handled directly in _append_message_stream,
+    # ContentThinkingDelta is handled directly in _append_message_stream,
     # but register it here so message_content_chunk doesn't raise for it.
     try:
         from chatlas.types import (
-            ContentThinking,  # pyright: ignore[reportAttributeAccessIssue]
+            ContentThinkingDelta,  # pyright: ignore[reportAttributeAccessIssue]
         )
 
         @message_content.register
-        def _(message: ContentThinking):
+        def _(message: ContentThinkingDelta):
             return ChatMessage(content=message.thinking)
 
         @message_content_chunk.register
-        def _(chunk: ContentThinking):
+        def _(chunk: ContentThinkingDelta):
             return ChatMessage(content=chunk.thinking)
     except ImportError:
         pass

--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     bslib,
     cli,
     coro,
-    ellmer (>= 0.4.0.9000),
+    ellmer (>= 0.4.1.9000),
     fastmap,
     htmltools,
     jsonlite,

--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -140,8 +140,10 @@ S7::method(contents_shinychat, ellmer::ContentThinking) <- function(content) {
   structure(content@thinking, class = "shinychat_thinking")
 }
 
-S7::method(contents_shinychat, ellmer::ContentThinkingDelta) <- function(content) {
-  structure(content@thinking, class = "shinychat_thinking")
+if (exists("ContentThinkingDelta", envir = asNamespace("ellmer"))) {
+  S7::method(contents_shinychat, ellmer::ContentThinkingDelta) <- function(content) {
+    structure(content@thinking, class = "shinychat_thinking")
+  }
 }
 
 new_tool_card <- function(type, request_id, tool_name, ...) {

--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -140,6 +140,10 @@ S7::method(contents_shinychat, ellmer::ContentThinking) <- function(content) {
   structure(content@thinking, class = "shinychat_thinking")
 }
 
+S7::method(contents_shinychat, ellmer::ContentThinkingDelta) <- function(content) {
+  structure(content@thinking, class = "shinychat_thinking")
+}
+
 new_tool_card <- function(type, request_id, tool_name, ...) {
   type <- arg_match(type, c("request", "result"))
 

--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -140,10 +140,8 @@ S7::method(contents_shinychat, ellmer::ContentThinking) <- function(content) {
   structure(content@thinking, class = "shinychat_thinking")
 }
 
-if (exists("ContentThinkingDelta", envir = asNamespace("ellmer"))) {
-  S7::method(contents_shinychat, ellmer::ContentThinkingDelta) <- function(content) {
-    structure(content@thinking, class = "shinychat_thinking")
-  }
+S7::method(contents_shinychat, ellmer::ContentThinkingDelta) <- function(content) {
+  structure(content@thinking, class = "shinychat_thinking")
 }
 
 new_tool_card <- function(type, request_id, tool_name, ...) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ Changelog = "https://github.com/posit-dev/shinychat/blob/main/pkg-py/CHANGELOG.m
 [project.optional-dependencies]
 providers = [
     "anthropic;python_version>='3.11'",
-    "chatlas[mcp]>=0.15.0",
+    "chatlas[mcp]>=0.16.0",
     "pydantic",
     "google-genai",
     "langchain-core>=1.0.0",


### PR DESCRIPTION
## Summary

Thinking content (`ContentThinkingDelta` and `ContentThinking`) now flows through the same normalization and message-sending pipeline as all other content types, instead of being special-cased in the stream loop. This makes thinking a property of the message rather than the code path, so non-streaming thinking (e.g., bookmark restore) works correctly without separate handling.

## Dependencies

- [posit-dev/chatlas#299](https://github.com/posit-dev/chatlas/pull/299) — adds `ContentThinkingDelta` to chatlas
- [tidyverse/ellmer#975](https://github.com/tidyverse/ellmer/pull/975) — adds `ContentThinkingDelta` to ellmer

## What this replaces

Alternative to [#210](https://github.com/posit-dev/shinychat/pull/210), which removed `content_type: "thinking"` from the wire protocol entirely. This PR keeps the typed wire protocol while achieving the server-side simplification.

## TODO

- [ ] Merge https://github.com/tidyverse/ellmer/pull/975
- [ ] After the next Chatlas release, bump its version requirement.