### PR TITLE
fix(pkg-py): resolve circular import on `import shinychat`

### DIFF
--- a/pkg-py/src/shinychat/_chat_bookmark.py
+++ b/pkg-py/src/shinychat/_chat_bookmark.py
@@ -1,8 +1,19 @@
+from __future__ import annotations
+
 import importlib.util
-from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Protocol,
+    runtime_checkable,
+)
 
 from htmltools import TagChild
-from shiny.types import Jsonifiable
+
+if TYPE_CHECKING:
+    from shiny.types import Jsonifiable
 
 chatlas_is_installed = importlib.util.find_spec("chatlas") is not None
 

--- a/pkg-py/tests/pytest/test_import.py
+++ b/pkg-py/tests/pytest/test_import.py
@@ -7,5 +7,6 @@ def test_no_circular_import():
         [sys.executable, "-c", "import shinychat"],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert result.returncode == 0, result.stderr

--- a/pkg-py/tests/pytest/test_import.py
+++ b/pkg-py/tests/pytest/test_import.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+
+
+def test_no_circular_import():
+    result = subprocess.run(
+        [sys.executable, "-c", "import shinychat"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Closes #207

## Summary

- `import shinychat` failed with a circular import when `shiny` was installed, because `_chat_bookmark.py` imported `shiny.types.Jsonifiable` at module level — triggering `shiny.__init__` → `shiny.ui._chat` → `from shinychat import Chat` before `shinychat` finished initializing.
- Deferred the `shiny.types.Jsonifiable` import to `TYPE_CHECKING` (it's only used in annotations) and added `from __future__ import annotations` to `_chat_bookmark.py`.
- Added a subprocess-based test that catches circular imports in a clean interpreter.

## Test plan

- [x] `python -c "import shinychat"` succeeds
- [x] `uv run pyright` passes (0 errors)
- [x] `uv run pytest pkg-py/tests/pytest/test_import.py` passes