### PR TITLE
chore: require latest ellmer release v0.4.1

### DIFF
--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     bslib,
     cli,
     coro,
-    ellmer (>= 0.4.0.9000),
+    ellmer (>= 0.4.1),
     fastmap,
     htmltools,
     jsonlite,
@@ -39,8 +39,6 @@ Suggests:
     later,
     testthat (>= 3.0.0),
     withr
-Remotes:
-    tidyverse/ellmer
 Config/Needs/website: tidyverse/tidytemplate, rmarkdown, weathR, gt, glue,
     bsicons
 Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
ellmer v0.4.1 was released; this bumps the required version and removes `Remotes` from `DESCRIPTION`