### PR TITLE
fix: align custom .tagify() annotations with htmltools Tagified contract

### DIFF
--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -46,13 +46,13 @@ jobs:
       - name: 📦 Install the project
         run: uv sync --python ${{ matrix.python-version }} --all-extras --all-groups
 
-      # TODO(htmltools-116): drop this step once py-shiny#2244 merges
-      # and a release ships. Installs shiny from the py-shiny PR
-      # branch (the Renderer.tagify() / App._render_page() fixes
-      # required by the new Tagifiable contract). See
-      # `py-install-pr-shiny` in the Makefile for why this is a
-      # post-sync step rather than a [tool.uv.sources] override.
-      - name: 📦 Install py-shiny#2244 (post-sync override)
+      # Workaround for the shiny → shinychat circular dep that
+      # prevents uv from resolving a tree with shiny>=1.6.2. The
+      # lockfile is pinned to an older shiny that lacks the
+      # Renderer.tagify() / App._render_page() updates required by
+      # htmltools 0.7.0; this step installs the latest shiny on top
+      # of the synced venv. See `py-install-pr-shiny` in the Makefile.
+      - name: 📦 Install latest shiny (post-sync workaround)
         run: make py-install-pr-shiny
 
       - name: 📜 Show uv.lock

--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -46,6 +46,15 @@ jobs:
       - name: 📦 Install the project
         run: uv sync --python ${{ matrix.python-version }} --all-extras --all-groups
 
+      # TODO(htmltools-116): drop this step once py-shiny#2244 merges
+      # and a release ships. Installs shiny from the py-shiny PR
+      # branch (the Renderer.tagify() / App._render_page() fixes
+      # required by the new Tagifiable contract). See
+      # `py-install-pr-shiny` in the Makefile for why this is a
+      # post-sync step rather than a [tool.uv.sources] override.
+      - name: 📦 Install py-shiny#2244 (post-sync override)
+        run: make py-install-pr-shiny
+
       - name: 📜 Show uv.lock
         run: cat uv.lock
 

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ r-docs-preview: ## [r] Build R docs
 	cd $(PATH_PKG_R) && Rscript -e "pkgdown::preview_site()"
 
 .PHONY: py-setup
-py-setup: py-install-pr-shiny  ## [py] Setup python environment
+py-setup: py-sync py-install-pr-shiny  ## [py] Setup python environment
 
 .PHONY: py-sync
 py-sync:
@@ -145,8 +145,12 @@ py-sync:
 # (shiny → shinychat → shiny), so we install it post-sync with
 # --no-deps. Drop this target once py-shiny#2244 merges and a release
 # ships.
+#
+# This target intentionally does NOT depend on `py-sync` so callers
+# (Makefile and CI) can choose when to sync; CI syncs in a separate
+# step before invoking this target.
 .PHONY: py-install-pr-shiny
-py-install-pr-shiny: py-sync
+py-install-pr-shiny:
 	@echo ""
 	@echo "📦 Installing py-shiny from posit-dev/py-shiny#2244"
 	# Use `uv pip install` (not `uv sync`) so the install runs at the
@@ -184,13 +188,15 @@ py-check-tests:  ## [py] Run python tests
 py-check-types:  ## [py] Run python type checks
 	@echo ""
 	@echo "📝 Checking types with pyright"
-	uv run pyright
+	# --no-sync so the post-sync py-shiny#2244 override isn't reverted.
+	uv run --no-sync pyright
 
 .PHONY: py-check-format
 py-check-format:
 	@echo ""
 	@echo "📐 Checking format with ruff"
-	uv run ruff check pkg-py --config pyproject.toml
+	# --no-sync so the post-sync py-shiny#2244 override isn't reverted.
+	uv run --no-sync ruff check pkg-py --config pyproject.toml
 
 .PHONY: py-format
 py-format: ## [py] Format python code

--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,35 @@ r-docs-preview: ## [r] Build R docs
 	cd $(PATH_PKG_R) && Rscript -e "pkgdown::preview_site()"
 
 .PHONY: py-setup
-py-setup:  ## [py] Setup python environment
+py-setup: py-install-pr-shiny  ## [py] Setup python environment
+
+.PHONY: py-sync
+py-sync:
 	uv sync --all-extras --all-groups --upgrade
+
+# TODO(htmltools-116): remove this target before merging. Installs
+# py-shiny from the posit-dev/py-shiny#2244 branch for the
+# Renderer.tagify() / App._render_page() fixes required by the new
+# Tagifiable contract (htmltools 0.7.0 / py-htmltools#120). Pinning
+# shiny via [tool.uv.sources] would create a circular resolution
+# (shiny → shinychat → shiny), so we install it post-sync with
+# --no-deps. Drop this target once py-shiny#2244 merges and a release
+# ships.
+.PHONY: py-install-pr-shiny
+py-install-pr-shiny: py-sync
+	@echo ""
+	@echo "📦 Installing py-shiny from posit-dev/py-shiny#2244"
+	# Use `uv pip install` (not `uv sync`) so the install runs at the
+	# package level and bypasses workspace resolution — `uv sync` would
+	# choke on the shiny → shinychat circular reference. `--no-deps` so
+	# uv doesn't replace the workspace shinychat with a PyPI build to
+	# satisfy py-shiny's own `shinychat>=0.1.0` requirement. Install
+	# `opentelemetry-api` separately because py-shiny#2244 added it as
+	# a new dep that the released shiny on PyPI didn't have, so `uv
+	# sync` won't have brought it in either.
+	uv pip install --reinstall --no-deps \
+		"shiny @ git+https://github.com/posit-dev/py-shiny.git@schloerke/htmltools-105-tagified-types"
+	uv pip install "opentelemetry-api>=1.20.0"
 
 .PHONY: py-check
 py-check:  py-check-format py-check-types py-check-tests ## [py] Run python checks
@@ -147,8 +174,11 @@ py-check-tox:  ## [py] Run python checks across versions with tox
 py-check-tests:  ## [py] Run python tests
 	@echo ""
 	@echo "🧪 Running tests with pytest"
-	uv run playwright install
-	uv run pytest
+	# Use --no-sync so the post-sync overrides applied in py-setup
+	# (notably the py-shiny#2244 install) aren't reverted by an
+	# implicit re-sync before each `uv run`. See py-install-pr-shiny.
+	uv run --no-sync playwright install
+	uv run --no-sync pytest
 
 .PHONY: py-check-types
 py-check-types:  ## [py] Run python type checks

--- a/Makefile
+++ b/Makefile
@@ -173,13 +173,15 @@ py-check-tox:  ## [py] Run python checks across versions with tox
 	@echo "🔄 Running tests and type checking with tox for Python 3.10--3.14"
 	uv run tox run-parallel
 
+# `--no-sync` everywhere below is required: without it, each `uv run`
+# implicitly re-syncs the lockfile-pinned shiny back over the latest
+# shiny installed by `py-install-pr-shiny`. See that target for why
+# we need the latest shiny in the first place.
+
 .PHONY: py-check-tests
 py-check-tests:  ## [py] Run python tests
 	@echo ""
 	@echo "🧪 Running tests with pytest"
-	# Use --no-sync so the post-sync overrides applied in py-setup
-	# (notably the py-shiny#2244 install) aren't reverted by an
-	# implicit re-sync before each `uv run`. See py-install-pr-shiny.
 	uv run --no-sync playwright install
 	uv run --no-sync pytest
 
@@ -187,14 +189,12 @@ py-check-tests:  ## [py] Run python tests
 py-check-types:  ## [py] Run python type checks
 	@echo ""
 	@echo "📝 Checking types with pyright"
-	# --no-sync so the post-sync py-shiny#2244 override isn't reverted.
 	uv run --no-sync pyright
 
 .PHONY: py-check-format
 py-check-format:
 	@echo ""
 	@echo "📐 Checking format with ruff"
-	# --no-sync so the post-sync py-shiny#2244 override isn't reverted.
 	uv run --no-sync ruff check pkg-py --config pyproject.toml
 
 .PHONY: py-format

--- a/Makefile
+++ b/Makefile
@@ -137,32 +137,31 @@ py-setup: py-sync py-install-pr-shiny  ## [py] Setup python environment
 py-sync:
 	uv sync --all-extras --all-groups --upgrade
 
-# TODO(htmltools-116): remove this target before merging. Installs
-# py-shiny from the posit-dev/py-shiny#2244 branch for the
-# Renderer.tagify() / App._render_page() fixes required by the new
-# Tagifiable contract (htmltools 0.7.0 / py-htmltools#120). Pinning
-# shiny via [tool.uv.sources] would create a circular resolution
-# (shiny → shinychat → shiny), so we install it post-sync with
-# --no-deps. Drop this target once py-shiny#2244 merges and a release
-# ships.
+# Post-sync workaround for the shiny → shinychat circular dep.
 #
-# This target intentionally does NOT depend on `py-sync` so callers
-# (Makefile and CI) can choose when to sync; CI syncs in a separate
-# step before invoking this target.
+# shiny>=1.6.2 depends on `shinychat>=0.1.0`. shinychat is *this*
+# project; uv refuses to satisfy that transitive constraint with the
+# workspace shinychat ("the name is shadowed by your project"), so
+# `uv lock`/`uv sync` cannot resolve a tree that includes shiny>=1.6.2.
+# The lockfile is pinned to an older shiny (1.4.0) — uv sync works,
+# but the env's shiny lacks the Renderer.tagify() / App._render_page()
+# updates required by the new Tagifiable contract (htmltools 0.7.0).
+#
+# Fix at the env level: install latest shiny on top of the synced
+# venv with `uv pip install` (which bypasses workspace resolution)
+# and `--no-deps` (so uv doesn't try to replace the workspace
+# shinychat to satisfy shiny's own `shinychat>=0.1.0`). Install
+# `opentelemetry-api` separately because shiny added it as a new
+# transitive dep but it's not in our shiny-1.4.0 lockfile.
+#
+# Intentionally does NOT depend on `py-sync` so callers (Makefile and
+# CI) can choose when to sync; CI syncs in a separate step before
+# invoking this target.
 .PHONY: py-install-pr-shiny
 py-install-pr-shiny:
 	@echo ""
-	@echo "📦 Installing py-shiny from posit-dev/py-shiny#2244"
-	# Use `uv pip install` (not `uv sync`) so the install runs at the
-	# package level and bypasses workspace resolution — `uv sync` would
-	# choke on the shiny → shinychat circular reference. `--no-deps` so
-	# uv doesn't replace the workspace shinychat with a PyPI build to
-	# satisfy py-shiny's own `shinychat>=0.1.0` requirement. Install
-	# `opentelemetry-api` separately because py-shiny#2244 added it as
-	# a new dep that the released shiny on PyPI didn't have, so `uv
-	# sync` won't have brought it in either.
-	uv pip install --reinstall --no-deps \
-		"shiny @ git+https://github.com/posit-dev/py-shiny.git@schloerke/htmltools-105-tagified-types"
+	@echo "📦 Installing latest shiny over the synced venv"
+	uv pip install --reinstall --no-deps "shiny>=1.6.2"
 	uv pip install "opentelemetry-api>=1.20.0"
 
 .PHONY: py-check

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,16 @@ py-sync:
 # Intentionally does NOT depend on `py-sync` so callers (Makefile and
 # CI) can choose when to sync; CI syncs in a separate step before
 # invoking this target.
+#
+# This target (and the `--no-sync` flags in the `py-check-*` targets
+# below, and the `[tool.uv]` NB in pyproject.toml) can all be dropped
+# once one of the following lands:
+#   - py-shiny stops depending on `shinychat` at runtime — e.g., moves
+#     it to a `shiny[chat]` extra. That breaks the cycle outright and
+#     `uv lock` / `uv sync` will resolve cleanly.
+#   - uv learns to satisfy a workspace-shadowed transitive dep with
+#     the workspace itself. Tracked upstream at
+#     https://github.com/astral-sh/uv/issues/9610.
 .PHONY: py-install-pr-shiny
 py-install-pr-shiny:
 	@echo ""

--- a/pkg-py/src/shinychat/_chat_bookmark.py
+++ b/pkg-py/src/shinychat/_chat_bookmark.py
@@ -11,11 +11,6 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    # `Tagified` is only available in htmltools >= 0.7.0; keep the
-    # import behind TYPE_CHECKING so this module still loads against
-    # the currently-released htmltools. The `from __future__ import
-    # annotations` line above defers the annotation, so the name
-    # never needs to resolve at runtime.
     from htmltools import Tagified
     from shiny.types import Jsonifiable
 

--- a/pkg-py/src/shinychat/_chat_bookmark.py
+++ b/pkg-py/src/shinychat/_chat_bookmark.py
@@ -10,9 +10,13 @@ from typing import (
     runtime_checkable,
 )
 
-from htmltools import Tagified
-
 if TYPE_CHECKING:
+    # `Tagified` is only available in htmltools >= 0.7.0; keep the
+    # import behind TYPE_CHECKING so this module still loads against
+    # the currently-released htmltools. The `from __future__ import
+    # annotations` line above defers the annotation, so the name
+    # never needs to resolve at runtime.
+    from htmltools import Tagified
     from shiny.types import Jsonifiable
 
 chatlas_is_installed = importlib.util.find_spec("chatlas") is not None

--- a/pkg-py/src/shinychat/_chat_bookmark.py
+++ b/pkg-py/src/shinychat/_chat_bookmark.py
@@ -10,7 +10,7 @@ from typing import (
     runtime_checkable,
 )
 
-from htmltools import TagChild
+from htmltools import Tagified
 
 if TYPE_CHECKING:
     from shiny.types import Jsonifiable
@@ -68,7 +68,7 @@ class BookmarkCancelCallback:
     def __call__(self):
         self.cancel()
 
-    def tagify(self) -> TagChild:
+    def tagify(self) -> Tagified:
         return ""
 
 

--- a/pkg-py/src/shinychat/_chat_normalize_chatlas.py
+++ b/pkg-py/src/shinychat/_chat_normalize_chatlas.py
@@ -12,7 +12,6 @@ from htmltools import (
     ReprHtml,
     Tag,
     Tagifiable,
-    Tagified,
     TagList,
 )
 from packaging import version
@@ -21,6 +20,13 @@ from typing_extensions import TypeAliasType
 
 if TYPE_CHECKING:
     from chatlas.types import ContentToolRequest, ContentToolResult
+
+    # `Tagified` is only available in htmltools >= 0.7.0; keep the
+    # import behind TYPE_CHECKING so this module still loads against
+    # the currently-released htmltools. The `from __future__ import
+    # annotations` line above defers the annotation, so the name
+    # never needs to resolve at runtime.
+    from htmltools import Tagified
 
 __all__ = [
     "ToolResultDisplay",

--- a/pkg-py/src/shinychat/_chat_normalize_chatlas.py
+++ b/pkg-py/src/shinychat/_chat_normalize_chatlas.py
@@ -20,12 +20,6 @@ from typing_extensions import TypeAliasType
 
 if TYPE_CHECKING:
     from chatlas.types import ContentToolRequest, ContentToolResult
-
-    # `Tagified` is only available in htmltools >= 0.7.0; keep the
-    # import behind TYPE_CHECKING so this module still loads against
-    # the currently-released htmltools. The `from __future__ import
-    # annotations` line above defers the annotation, so the name
-    # never needs to resolve at runtime.
     from htmltools import Tagified
 
 __all__ = [

--- a/pkg-py/src/shinychat/_chat_normalize_chatlas.py
+++ b/pkg-py/src/shinychat/_chat_normalize_chatlas.py
@@ -12,6 +12,7 @@ from htmltools import (
     ReprHtml,
     Tag,
     Tagifiable,
+    Tagified,
     TagList,
 )
 from packaging import version
@@ -83,7 +84,7 @@ class ToolRequestComponent(ToolCardComponent):
     arguments: str = ""
     "The function arguments as requested by the LLM, typically in JSON format."
 
-    def tagify(self):
+    def tagify(self) -> Tagified:
         icon_ui = TagList(self.icon).render()
 
         return Tag(
@@ -97,7 +98,7 @@ class ToolRequestComponent(ToolCardComponent):
             expanded="" if self.expanded else None,
             arguments=self.arguments,
             *icon_ui["dependencies"],
-        )
+        ).tagify()
 
 
 ValueType = Literal["html", "markdown", "text", "code"]
@@ -137,7 +138,7 @@ class ToolResultComponent(ToolCardComponent):
     full_screen: bool = False
     "Controls whether a fullscreen toggle button is displayed on the card."
 
-    def tagify(self):
+    def tagify(self) -> Tagified:
         icon_ui = TagList(self.icon).render()
 
         if self.value_type == "html":
@@ -169,7 +170,7 @@ class ToolResultComponent(ToolCardComponent):
             *icon_ui["dependencies"],
             *value_ui["dependencies"],
             *footer_ui["dependencies"],
-        )
+        ).tagify()
 
 
 class ToolResultDisplay(BaseModel):

--- a/pkg-py/src/shinychat/_html_islands.py
+++ b/pkg-py/src/shinychat/_html_islands.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from itertools import groupby
 
-from htmltools import Tag, TagChild, Tagifiable, TagList
+from htmltools import (
+    Tag,
+    TagChild,
+    Tagifiable,
+    TagifiedTag,
+    TagifiedTagList,
+    TagList,
+)
 
 
 def _resolve_tagifiable(content: TagChild) -> TagChild:
     """Resolve a Tagifiable to its Tag form (if it isn't already a Tag/TagList/str)."""
-    if isinstance(content, (Tag, TagList, str)):
+    if isinstance(content, (Tag, TagifiedTag, TagList, TagifiedTagList, str)):
         return content
     if isinstance(content, Tagifiable):
         return content.tagify()
@@ -17,7 +24,7 @@ def _resolve_tagifiable(content: TagChild) -> TagChild:
 def _has_react_attr(child: TagChild) -> bool:
     """Check if a tag child has the data-shinychat-react attribute."""
     child = _resolve_tagifiable(child)
-    if isinstance(child, Tag):
+    if isinstance(child, (Tag, TagifiedTag)):
         return "data-shinychat-react" in child.attrs
     return False
 
@@ -32,15 +39,15 @@ def split_html_islands(content: TagChild | TagList) -> list[TagChild]:
 
     Returns a list of TagChild items ready to be serialized.
     """
-    if isinstance(content, TagList):
+    if isinstance(content, (TagList, TagifiedTagList)):
         children = list(content)
-    elif isinstance(content, Tag):
+    elif isinstance(content, (Tag, TagifiedTag)):
         if _has_react_attr(content):
             return [content]
         return [Tag("shinychat-raw-html", content)]
     elif isinstance(content, Tagifiable):
         resolved = content.tagify()
-        if isinstance(resolved, Tag) and _has_react_attr(resolved):
+        if isinstance(resolved, (Tag, TagifiedTag)) and _has_react_attr(resolved):
             return [resolved]
         return [Tag("shinychat-raw-html", content)]
     else:

--- a/pkg-py/tests/pytest/test_html_islands.py
+++ b/pkg-py/tests/pytest/test_html_islands.py
@@ -114,7 +114,7 @@ def test_tagifiable_without_react_attr_wrapped():
 
     class FakeWidget(Tagifiable):
         def tagify(self):
-            return div("widget content")
+            return div("widget content").tagify()
 
     result = split_html_islands(FakeWidget())
     rendered = TagList(result).render()["html"]
@@ -132,7 +132,7 @@ def test_tagifiable_in_taglist_splits_correctly():
                 "shiny-tool-result",
                 data_shinychat_react=True,
                 request_id="test-456",
-            )
+            ).tagify()
 
     tl = TagList(div("before"), FakeToolResult(), div("after"))
     result = split_html_islands(tl)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,13 @@ dev = [
 [tool.uv]
 upgrade-package = ["shinychat"]
 
-# NB: shiny also needs the py-shiny#2244 branch for the
-# Renderer.tagify() / App._render_page() fixes required by the new
-# Tagifiable contract, but a `[tool.uv.sources]` override for shiny
-# creates a circular resolution (shiny→shinychat→shiny). The
-# Makefile installs that shiny build after `uv sync` instead — see
-# the `py-install-pr-shiny` target in Makefile.
+# NB: shiny>=1.6.2 depends on `shinychat>=0.1.0` (this project),
+# which uv refuses to satisfy through the workspace. As a result
+# `uv lock`/`uv sync` can't resolve a tree with the latest shiny
+# (the lockfile is pinned to an older shiny that lacks the
+# Renderer.tagify() / App._render_page() updates for htmltools
+# 0.7.0). The Makefile's `py-install-pr-shiny` target installs the
+# latest shiny on top of the synced venv as a post-sync workaround.
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,12 @@ dev = [
 [tool.uv]
 upgrade-package = ["shinychat"]
 
-# TODO(htmltools-105): remove this source override before merging.
-# Pins htmltools to the PR branch that adds the `Tagified` alias
-# (posit-dev/py-htmltools#106). Flip back to the released htmltools
-# once it ships.
+# TODO(htmltools-116): remove this source override before merging.
+# Pins htmltools to PR #120 (the sibling-classes refactor for
+# tagified content). Flip back to the released htmltools once 0.7.0
+# ships.
 [tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/issue-116-sibling-classes" }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,9 @@ dev = [
 [tool.uv]
 upgrade-package = ["shinychat"]
 
-# NB: shiny>=1.6.2 depends on `shinychat>=0.1.0` (this project),
-# which uv refuses to satisfy through the workspace. As a result
-# `uv lock`/`uv sync` can't resolve a tree with the latest shiny
-# (the lockfile is pinned to an older shiny that lacks the
-# Renderer.tagify() / App._render_page() updates for htmltools
-# 0.7.0). The Makefile's `py-install-pr-shiny` target installs the
-# latest shiny on top of the synced venv as a post-sync workaround.
+# shiny>=1.6.2 depends on `shinychat` (this project), which uv can't
+# satisfy through the workspace. See `py-install-pr-shiny` in the
+# Makefile for the post-sync workaround.
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ dev = [
 [tool.uv]
 upgrade-package = ["shinychat"]
 
+# TODO(htmltools-105): remove this source override before merging.
+# Pins htmltools to the PR branch that adds the `Tagified` alias
+# (posit-dev/py-htmltools#106). Flip back to the released htmltools
+# once it ships.
+[tool.uv.sources]
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue" }
+
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,13 @@ upgrade-package = ["shinychat"]
 # Pins htmltools to PR #120 (the sibling-classes refactor for
 # tagified content). Flip back to the released htmltools once 0.7.0
 # ships.
+#
+# NB: shiny also needs the py-shiny#2244 branch for the
+# Renderer.tagify() / App._render_page() fixes required by the new
+# Tagifiable contract, but a `[tool.uv.sources]` override for shiny
+# creates a circular resolution (shiny→shinychat→shiny). The
+# Makefile installs that shiny build after `uv sync` instead — see
+# the `py-install-pr-shiny` target in Makefile.
 [tool.uv.sources]
 htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ upgrade-package = ["shinychat"]
 # tagified content). Flip back to the released htmltools once 0.7.0
 # ships.
 [tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/issue-116-sibling-classes" }
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "pkg-py/README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
-    "htmltools>=0.6.0",
+    "htmltools>=0.7.0",
     "shiny>=1.4.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ upgrade-package = ["shinychat"]
 # (posit-dev/py-htmltools#106). Flip back to the released htmltools
 # once it ships.
 [tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue" }
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,19 +59,12 @@ dev = [
 [tool.uv]
 upgrade-package = ["shinychat"]
 
-# TODO(htmltools-116): remove this source override before merging.
-# Pins htmltools to PR #120 (the sibling-classes refactor for
-# tagified content). Flip back to the released htmltools once 0.7.0
-# ships.
-#
 # NB: shiny also needs the py-shiny#2244 branch for the
 # Renderer.tagify() / App._render_page() fixes required by the new
 # Tagifiable contract, but a `[tool.uv.sources]` override for shiny
 # creates a circular resolution (shiny→shinychat→shiny). The
 # Makefile installs that shiny build after `uv sync` instead — see
 # the `py-install-pr-shiny` target in Makefile.
-[tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]


### PR DESCRIPTION
## Summary

The upcoming htmltools 0.7.0 release ([posit-dev/py-htmltools#120](https://github.com/posit-dev/py-htmltools/pull/120), closes posit-dev/py-htmltools#116) refactors tagified content into immutable sibling classes and tightens the `Tagifiable.tagify()` Protocol return type to `Tagified`. `Tagified` is a tighter union than the previous bare `TagList | Tag | MetadataNode | str | HTML`: it excludes the un-resolved `Tagifiable` arm and is the only tagified-shape alias exported by htmltools — downstream `.tagify()` implementations should annotate `-> Tagified` exclusively. Custom `.tagify()` implementations whose return is wider than `Tagified` no longer satisfy the protocol in strict-mode type checkers.

Changes:

- **`_chat_bookmark.py`**: change `def tagify(self) -> TagChild: return ""` to `-> Tagified`. The previous `TagChild` annotation was wider than the protocol return type (`TagChild` includes `float`/`None`/`Sequence`/etc.).
- **`_chat_normalize_chatlas.py`**: annotate both `def tagify(self):` methods as `-> Tagified` and call `.tagify()` on the returned `Tag(…)` so the value is properly tagified (matches the recursive invariant the protocol now expresses).

Pyright (basic mode, as configured) is already clean with the released htmltools; these changes make the code also correct under the upcoming protocol tightening.

## Dependency

Depends on [posit-dev/py-htmltools#120](https://github.com/posit-dev/py-htmltools/pull/120). The `[tool.uv.sources]` git pin currently points at the PR branch; revert to released `htmltools>=0.7.0` once it ships on PyPI.

## Test plan

- [x] Pyright against the new htmltools → 0 errors
- [x] Functional behavior is unchanged — `.tagify()` on a leaf-only `Tag` is a no-op at runtime