### PR TITLE
Release v0.4.0

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.2] - Unreleased
+## [0.3.2] - 2026-05-21
+
+### Bug fixes
+
+* Updated for compatibility with htmltools 0.7.0. `split_html_islands` now recognizes the new `TagifiedTag` / `TagifiedTagList` sibling classes when deciding which children carry the `data-shinychat-react` attribute, and `Tool*Component.tagify()` implementations are annotated with `htmltools.Tagified` and return fully-tagified output per the new Tagifiable contract. (#226)
 
 ### New features
 

--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -5,11 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.2] - 2026-05-21
-
-### Bug fixes
-
-* Updated for compatibility with htmltools 0.7.0. `split_html_islands` now recognizes the new `TagifiedTag` / `TagifiedTagList` sibling classes when deciding which children carry the `data-shinychat-react` attribute, and `Tool*Component.tagify()` implementations are annotated with `htmltools.Tagified` and return fully-tagified output per the new Tagifiable contract. (#226)
+## [0.4.0] - 2026-05-21
 
 ### New features
 
@@ -24,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improvements
 
 * Updated minimum `chatlas` version to `>=0.15.0`. (#208)
+
+### Bug fixes
+
+* Updated for compatibility with htmltools 0.7.0. `split_html_islands` now recognizes the new `TagifiedTag` / `TagifiedTagList` sibling classes when deciding which children carry the `data-shinychat-react` attribute, and `Tool*Component.tagify()` implementations are annotated with `htmltools.Tagified` and return fully-tagified output per the new Tagifiable contract. (#226)
 
 ## [0.3.1] - 2026-04-30
 


### PR DESCRIPTION
## Summary

Cuts shinychat **0.4.0** (date: 2026-05-21) since 0.3.1:

- **#225** (New features) — tool result cards render images and PDFs from chatlas content items.
- **#221** (New features) — `enable_cancel` param + stop button wired to `chatlas.StreamController`.
- **#219** (New features) — suggestion-list spans rendered as a clickable suggestion-card grid.
- **#208** (New features + Improvements) — thinking-content panels; `chatlas>=0.15.0` floor.
- **#226** (Bug fixes) — htmltools 0.7.0 / Tagifiable-contract compat for `split_html_islands` and the `Tool*Component.tagify()` implementations.
- [ ] **#227** (New features) — adds `set_client()` and status to `chat_mod_server()` return value

Minor-version bump (0.3.x → 0.4.0) reflects the new user-facing features.

## Commits

- `Release v0.3.2` — renames `## [0.3.2] - Unreleased` → `## [0.3.2] - 2026-05-21` and adds the `### Bug fixes` subsection for #226.
- `chore(py): bump release to v0.4.0 and reorder changelog sections` — bumps the heading to `[0.4.0] - 2026-05-21` and reorders subsections to `New features` → `Improvements` → `Bug fixes`.

## After merge

1. Tag the merge commit `v0.4.0`.
2. Publish a GitHub Release on that tag.
3. The release workflow handles `uv build` + trusted PyPI publish.

`hatch-vcs` derives the version from the tag.