### PR TITLE
chore(py): drop unnecessary shiny post-sync workaround from #226

### DIFF
--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -34,6 +34,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need full history + tags so hatch-vcs computes a real
+          # workspace version (e.g. 0.3.2.devN+gSHA, derived from the
+          # latest py/v* tag) instead of the fallback 0.1.dev1+gSHA.
+          # The fallback sorts before 0.1.0 (PEP 440), so it can't
+          # satisfy shiny>=1.5's transitive `shinychat>=0.1.0` and
+          # uv silently downgrades shiny to 1.4.0, which lacks the
+          # htmltools-0.7.0 Tagifiable fixes.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: 🚀 Install uv
         uses: astral-sh/setup-uv@v6.1.0

--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -46,15 +46,6 @@ jobs:
       - name: 📦 Install the project
         run: uv sync --python ${{ matrix.python-version }} --all-extras --all-groups
 
-      # Workaround for the shiny → shinychat circular dep that
-      # prevents uv from resolving a tree with shiny>=1.6.2. The
-      # lockfile is pinned to an older shiny that lacks the
-      # Renderer.tagify() / App._render_page() updates required by
-      # htmltools 0.7.0; this step installs the latest shiny on top
-      # of the synced venv. See `py-install-pr-shiny` in the Makefile.
-      - name: 📦 Install latest shiny (post-sync workaround)
-        run: make py-install-pr-shiny
-
       - name: 📜 Show uv.lock
         run: cat uv.lock
 

--- a/Makefile
+++ b/Makefile
@@ -131,48 +131,8 @@ r-docs-preview: ## [r] Build R docs
 	cd $(PATH_PKG_R) && Rscript -e "pkgdown::preview_site()"
 
 .PHONY: py-setup
-py-setup: py-sync py-install-pr-shiny  ## [py] Setup python environment
-
-.PHONY: py-sync
-py-sync:
+py-setup:  ## [py] Setup python environment
 	uv sync --all-extras --all-groups --upgrade
-
-# Post-sync workaround for the shiny → shinychat circular dep.
-#
-# shiny>=1.6.2 depends on `shinychat>=0.1.0`. shinychat is *this*
-# project; uv refuses to satisfy that transitive constraint with the
-# workspace shinychat ("the name is shadowed by your project"), so
-# `uv lock`/`uv sync` cannot resolve a tree that includes shiny>=1.6.2.
-# The lockfile is pinned to an older shiny (1.4.0) — uv sync works,
-# but the env's shiny lacks the Renderer.tagify() / App._render_page()
-# updates required by the new Tagifiable contract (htmltools 0.7.0).
-#
-# Fix at the env level: install latest shiny on top of the synced
-# venv with `uv pip install` (which bypasses workspace resolution)
-# and `--no-deps` (so uv doesn't try to replace the workspace
-# shinychat to satisfy shiny's own `shinychat>=0.1.0`). Install
-# `opentelemetry-api` separately because shiny added it as a new
-# transitive dep but it's not in our shiny-1.4.0 lockfile.
-#
-# Intentionally does NOT depend on `py-sync` so callers (Makefile and
-# CI) can choose when to sync; CI syncs in a separate step before
-# invoking this target.
-#
-# This target (and the `--no-sync` flags in the `py-check-*` targets
-# below, and the `[tool.uv]` NB in pyproject.toml) can all be dropped
-# once one of the following lands:
-#   - py-shiny stops depending on `shinychat` at runtime — e.g., moves
-#     it to a `shiny[chat]` extra. That breaks the cycle outright and
-#     `uv lock` / `uv sync` will resolve cleanly.
-#   - uv learns to satisfy a workspace-shadowed transitive dep with
-#     the workspace itself. Tracked upstream at
-#     https://github.com/astral-sh/uv/issues/9610.
-.PHONY: py-install-pr-shiny
-py-install-pr-shiny:
-	@echo ""
-	@echo "📦 Installing latest shiny over the synced venv"
-	uv pip install --reinstall --no-deps "shiny>=1.6.2"
-	uv pip install "opentelemetry-api>=1.20.0"
 
 .PHONY: py-check
 py-check:  py-check-format py-check-types py-check-tests ## [py] Run python checks
@@ -183,29 +143,24 @@ py-check-tox:  ## [py] Run python checks across versions with tox
 	@echo "🔄 Running tests and type checking with tox for Python 3.10--3.14"
 	uv run tox run-parallel
 
-# `--no-sync` everywhere below is required: without it, each `uv run`
-# implicitly re-syncs the lockfile-pinned shiny back over the latest
-# shiny installed by `py-install-pr-shiny`. See that target for why
-# we need the latest shiny in the first place.
-
 .PHONY: py-check-tests
 py-check-tests:  ## [py] Run python tests
 	@echo ""
 	@echo "🧪 Running tests with pytest"
-	uv run --no-sync playwright install
-	uv run --no-sync pytest
+	uv run playwright install
+	uv run pytest
 
 .PHONY: py-check-types
 py-check-types:  ## [py] Run python type checks
 	@echo ""
 	@echo "📝 Checking types with pyright"
-	uv run --no-sync pyright
+	uv run pyright
 
 .PHONY: py-check-format
 py-check-format:
 	@echo ""
 	@echo "📐 Checking format with ruff"
-	uv run --no-sync ruff check pkg-py --config pyproject.toml
+	uv run ruff check pkg-py --config pyproject.toml
 
 .PHONY: py-format
 py-format: ## [py] Format python code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,6 @@ dev = [
     {include-group = "test"},
 ]
 
-[tool.uv]
-upgrade-package = ["shinychat"]
-
-# shiny>=1.6.2 depends on `shinychat` (this project), which uv can't
-# satisfy through the workspace. See `py-install-pr-shiny` in the
-# Makefile for the post-sync workaround.
-
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

- #226 added a `py-install-pr-shiny` Makefile target, matching `--no-sync` flags on the `py-check-*` targets, a CI step, and a `[tool.uv]` block in `pyproject.toml` to work around what was described as a circular `shiny ↔ shinychat` resolution failure. Empirically that resolution failure doesn't happen with uv 0.9.x — a fresh `uv lock` / `uv sync` resolves `shiny==1.6.2`, the editable workspace `shinychat`, and `opentelemetry-api==1.42.1` cleanly, and `make py-check-{format,types,tests}` (65 tests) all pass against the resulting env with no override.
- Likely root cause at PR time: a stale local `uv.lock` pinned to an older `shiny` (the lockfile is `.gitignore`d, so a fresh checkout has none). The workaround papered over that rather than refreshing the lockfile.
- Removes: the `py-install-pr-shiny` Makefile target and its rationale block, the intermediate `py-sync` target (inlines `uv sync` back into `py-setup`, matching pre-#226 shape), the `--no-sync` flags on `py-check-tests/-types/-format`, the dedicated CI workaround step, and the `[tool.uv]` block in `pyproject.toml`.

## Test plan

- [x] Delete local `uv.lock`, run `uv sync --all-extras --all-groups --upgrade` — installs `shiny==1.6.2` and `opentelemetry-api==1.42.1` with no override
- [x] `make py-check-format` — passes
- [x] `make py-check-types` — 0 errors, 0 warnings
- [x] `make py-check-tests` — 65 passed
- [ ] CI green on this PR