### PR TITLE
Release py/v0.3.2 (patch: htmltools 0.7.0 compatibility)

### DIFF
--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -34,6 +34,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need full history + tags so hatch-vcs computes a real
+          # workspace version (e.g. 0.3.2.devN+gSHA, derived from the
+          # latest py/v* tag) instead of the fallback 0.1.dev1+gSHA.
+          # The fallback sorts before 0.1.0 (PEP 440), so it can't
+          # satisfy shiny>=1.5's transitive `shinychat>=0.1.0` and
+          # uv silently downgrades shiny to 1.4.0, which lacks the
+          # htmltools-0.7.0 Tagifiable fixes.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: 🚀 Install uv
         uses: astral-sh/setup-uv@v6.1.0
@@ -45,15 +55,6 @@ jobs:
 
       - name: 📦 Install the project
         run: uv sync --python ${{ matrix.python-version }} --all-extras --all-groups
-
-      # Workaround for the shiny → shinychat circular dep that
-      # prevents uv from resolving a tree with shiny>=1.6.2. The
-      # lockfile is pinned to an older shiny that lacks the
-      # Renderer.tagify() / App._render_page() updates required by
-      # htmltools 0.7.0; this step installs the latest shiny on top
-      # of the synced venv. See `py-install-pr-shiny` in the Makefile.
-      - name: 📦 Install latest shiny (post-sync workaround)
-        run: make py-install-pr-shiny
 
       - name: 📜 Show uv.lock
         run: cat uv.lock

--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -46,6 +46,15 @@ jobs:
       - name: 📦 Install the project
         run: uv sync --python ${{ matrix.python-version }} --all-extras --all-groups
 
+      # Workaround for the shiny → shinychat circular dep that
+      # prevents uv from resolving a tree with shiny>=1.6.2. The
+      # lockfile is pinned to an older shiny that lacks the
+      # Renderer.tagify() / App._render_page() updates required by
+      # htmltools 0.7.0; this step installs the latest shiny on top
+      # of the synced venv. See `py-install-pr-shiny` in the Makefile.
+      - name: 📦 Install latest shiny (post-sync workaround)
+        run: make py-install-pr-shiny
+
       - name: 📜 Show uv.lock
         run: cat uv.lock
 

--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,48 @@ r-docs-preview: ## [r] Build R docs
 	cd $(PATH_PKG_R) && Rscript -e "pkgdown::preview_site()"
 
 .PHONY: py-setup
-py-setup:  ## [py] Setup python environment
+py-setup: py-sync py-install-pr-shiny  ## [py] Setup python environment
+
+.PHONY: py-sync
+py-sync:
 	uv sync --all-extras --all-groups --upgrade
+
+# Post-sync workaround for the shiny → shinychat circular dep.
+#
+# shiny>=1.6.2 depends on `shinychat>=0.1.0`. shinychat is *this*
+# project; uv refuses to satisfy that transitive constraint with the
+# workspace shinychat ("the name is shadowed by your project"), so
+# `uv lock`/`uv sync` cannot resolve a tree that includes shiny>=1.6.2.
+# The lockfile is pinned to an older shiny (1.4.0) — uv sync works,
+# but the env's shiny lacks the Renderer.tagify() / App._render_page()
+# updates required by the new Tagifiable contract (htmltools 0.7.0).
+#
+# Fix at the env level: install latest shiny on top of the synced
+# venv with `uv pip install` (which bypasses workspace resolution)
+# and `--no-deps` (so uv doesn't try to replace the workspace
+# shinychat to satisfy shiny's own `shinychat>=0.1.0`). Install
+# `opentelemetry-api` separately because shiny added it as a new
+# transitive dep but it's not in our shiny-1.4.0 lockfile.
+#
+# Intentionally does NOT depend on `py-sync` so callers (Makefile and
+# CI) can choose when to sync; CI syncs in a separate step before
+# invoking this target.
+#
+# This target (and the `--no-sync` flags in the `py-check-*` targets
+# below, and the `[tool.uv]` NB in pyproject.toml) can all be dropped
+# once one of the following lands:
+#   - py-shiny stops depending on `shinychat` at runtime — e.g., moves
+#     it to a `shiny[chat]` extra. That breaks the cycle outright and
+#     `uv lock` / `uv sync` will resolve cleanly.
+#   - uv learns to satisfy a workspace-shadowed transitive dep with
+#     the workspace itself. Tracked upstream at
+#     https://github.com/astral-sh/uv/issues/9610.
+.PHONY: py-install-pr-shiny
+py-install-pr-shiny:
+	@echo ""
+	@echo "📦 Installing latest shiny over the synced venv"
+	uv pip install --reinstall --no-deps "shiny>=1.6.2"
+	uv pip install "opentelemetry-api>=1.20.0"
 
 .PHONY: py-check
 py-check:  py-check-format py-check-types py-check-tests ## [py] Run python checks
@@ -143,24 +183,29 @@ py-check-tox:  ## [py] Run python checks across versions with tox
 	@echo "🔄 Running tests and type checking with tox for Python 3.10--3.14"
 	uv run tox run-parallel
 
+# `--no-sync` everywhere below is required: without it, each `uv run`
+# implicitly re-syncs the lockfile-pinned shiny back over the latest
+# shiny installed by `py-install-pr-shiny`. See that target for why
+# we need the latest shiny in the first place.
+
 .PHONY: py-check-tests
 py-check-tests:  ## [py] Run python tests
 	@echo ""
 	@echo "🧪 Running tests with pytest"
-	uv run playwright install
-	uv run pytest
+	uv run --no-sync playwright install
+	uv run --no-sync pytest
 
 .PHONY: py-check-types
 py-check-types:  ## [py] Run python type checks
 	@echo ""
 	@echo "📝 Checking types with pyright"
-	uv run pyright
+	uv run --no-sync pyright
 
 .PHONY: py-check-format
 py-check-format:
 	@echo ""
 	@echo "📐 Checking format with ruff"
-	uv run ruff check pkg-py --config pyproject.toml
+	uv run --no-sync ruff check pkg-py --config pyproject.toml
 
 .PHONY: py-format
 py-format: ## [py] Format python code

--- a/Makefile
+++ b/Makefile
@@ -131,48 +131,8 @@ r-docs-preview: ## [r] Build R docs
 	cd $(PATH_PKG_R) && Rscript -e "pkgdown::preview_site()"
 
 .PHONY: py-setup
-py-setup: py-sync py-install-pr-shiny  ## [py] Setup python environment
-
-.PHONY: py-sync
-py-sync:
+py-setup:  ## [py] Setup python environment
 	uv sync --all-extras --all-groups --upgrade
-
-# Post-sync workaround for the shiny → shinychat circular dep.
-#
-# shiny>=1.6.2 depends on `shinychat>=0.1.0`. shinychat is *this*
-# project; uv refuses to satisfy that transitive constraint with the
-# workspace shinychat ("the name is shadowed by your project"), so
-# `uv lock`/`uv sync` cannot resolve a tree that includes shiny>=1.6.2.
-# The lockfile is pinned to an older shiny (1.4.0) — uv sync works,
-# but the env's shiny lacks the Renderer.tagify() / App._render_page()
-# updates required by the new Tagifiable contract (htmltools 0.7.0).
-#
-# Fix at the env level: install latest shiny on top of the synced
-# venv with `uv pip install` (which bypasses workspace resolution)
-# and `--no-deps` (so uv doesn't try to replace the workspace
-# shinychat to satisfy shiny's own `shinychat>=0.1.0`). Install
-# `opentelemetry-api` separately because shiny added it as a new
-# transitive dep but it's not in our shiny-1.4.0 lockfile.
-#
-# Intentionally does NOT depend on `py-sync` so callers (Makefile and
-# CI) can choose when to sync; CI syncs in a separate step before
-# invoking this target.
-#
-# This target (and the `--no-sync` flags in the `py-check-*` targets
-# below, and the `[tool.uv]` NB in pyproject.toml) can all be dropped
-# once one of the following lands:
-#   - py-shiny stops depending on `shinychat` at runtime — e.g., moves
-#     it to a `shiny[chat]` extra. That breaks the cycle outright and
-#     `uv lock` / `uv sync` will resolve cleanly.
-#   - uv learns to satisfy a workspace-shadowed transitive dep with
-#     the workspace itself. Tracked upstream at
-#     https://github.com/astral-sh/uv/issues/9610.
-.PHONY: py-install-pr-shiny
-py-install-pr-shiny:
-	@echo ""
-	@echo "📦 Installing latest shiny over the synced venv"
-	uv pip install --reinstall --no-deps "shiny>=1.6.2"
-	uv pip install "opentelemetry-api>=1.20.0"
 
 .PHONY: py-check
 py-check:  py-check-format py-check-types py-check-tests ## [py] Run python checks
@@ -183,29 +143,24 @@ py-check-tox:  ## [py] Run python checks across versions with tox
 	@echo "🔄 Running tests and type checking with tox for Python 3.10--3.14"
 	uv run tox run-parallel
 
-# `--no-sync` everywhere below is required: without it, each `uv run`
-# implicitly re-syncs the lockfile-pinned shiny back over the latest
-# shiny installed by `py-install-pr-shiny`. See that target for why
-# we need the latest shiny in the first place.
-
 .PHONY: py-check-tests
 py-check-tests:  ## [py] Run python tests
 	@echo ""
 	@echo "🧪 Running tests with pytest"
-	uv run --no-sync playwright install
-	uv run --no-sync pytest
+	uv run playwright install
+	uv run pytest
 
 .PHONY: py-check-types
 py-check-types:  ## [py] Run python type checks
 	@echo ""
 	@echo "📝 Checking types with pyright"
-	uv run --no-sync pyright
+	uv run pyright
 
 .PHONY: py-check-format
 py-check-format:
 	@echo ""
 	@echo "📐 Checking format with ruff"
-	uv run --no-sync ruff check pkg-py --config pyproject.toml
+	uv run ruff check pkg-py --config pyproject.toml
 
 .PHONY: py-format
 py-format: ## [py] Format python code

--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-05-21
+
+### Bug fixes
+
+* Updated for compatibility with htmltools 0.7.0. `split_html_islands` now recognizes the new `TagifiedTag` / `TagifiedTagList` sibling classes when deciding which children carry the `data-shinychat-react` attribute, and `Tool*Component.tagify()` implementations are annotated with `htmltools.Tagified` and return fully-tagified output per the new Tagifiable contract. (#226)
+
 ## [0.3.1] - 2026-04-30
 
 ### Bug fixes

--- a/pkg-py/src/shinychat/_chat_bookmark.py
+++ b/pkg-py/src/shinychat/_chat_bookmark.py
@@ -1,7 +1,7 @@
 import importlib.util
 from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
 
-from htmltools import TagChild
+from htmltools import Tagified
 from shiny.types import Jsonifiable
 
 chatlas_is_installed = importlib.util.find_spec("chatlas") is not None
@@ -57,7 +57,7 @@ class BookmarkCancelCallback:
     def __call__(self):
         self.cancel()
 
-    def tagify(self) -> TagChild:
+    def tagify(self) -> Tagified:
         return ""
 
 

--- a/pkg-py/src/shinychat/_chat_normalize_chatlas.py
+++ b/pkg-py/src/shinychat/_chat_normalize_chatlas.py
@@ -20,6 +20,7 @@ from typing_extensions import TypeAliasType
 
 if TYPE_CHECKING:
     from chatlas.types import ContentToolRequest, ContentToolResult
+    from htmltools import Tagified
 
 __all__ = [
     "ToolResultDisplay",
@@ -83,7 +84,7 @@ class ToolRequestComponent(ToolCardComponent):
     arguments: str = ""
     "The function arguments as requested by the LLM, typically in JSON format."
 
-    def tagify(self):
+    def tagify(self) -> Tagified:
         icon_ui = TagList(self.icon).render()
 
         return Tag(
@@ -97,7 +98,7 @@ class ToolRequestComponent(ToolCardComponent):
             expanded="" if self.expanded else None,
             arguments=self.arguments,
             *icon_ui["dependencies"],
-        )
+        ).tagify()
 
 
 ValueType = Literal["html", "markdown", "text", "code"]
@@ -137,7 +138,7 @@ class ToolResultComponent(ToolCardComponent):
     full_screen: bool = False
     "Controls whether a fullscreen toggle button is displayed on the card."
 
-    def tagify(self):
+    def tagify(self) -> Tagified:
         icon_ui = TagList(self.icon).render()
 
         if self.value_type == "html":
@@ -169,7 +170,7 @@ class ToolResultComponent(ToolCardComponent):
             *icon_ui["dependencies"],
             *value_ui["dependencies"],
             *footer_ui["dependencies"],
-        )
+        ).tagify()
 
 
 class ToolResultDisplay(BaseModel):

--- a/pkg-py/src/shinychat/_html_islands.py
+++ b/pkg-py/src/shinychat/_html_islands.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from itertools import groupby
 
-from htmltools import Tag, TagChild, Tagifiable, TagList
+from htmltools import (
+    Tag,
+    TagChild,
+    Tagifiable,
+    TagifiedTag,
+    TagifiedTagList,
+    TagList,
+)
 
 
 def _resolve_tagifiable(content: TagChild) -> TagChild:
     """Resolve a Tagifiable to its Tag form (if it isn't already a Tag/TagList/str)."""
-    if isinstance(content, (Tag, TagList, str)):
+    if isinstance(content, (Tag, TagifiedTag, TagList, TagifiedTagList, str)):
         return content
     if isinstance(content, Tagifiable):
         return content.tagify()
@@ -17,7 +24,7 @@ def _resolve_tagifiable(content: TagChild) -> TagChild:
 def _has_react_attr(child: TagChild) -> bool:
     """Check if a tag child has the data-shinychat-react attribute."""
     child = _resolve_tagifiable(child)
-    if isinstance(child, Tag):
+    if isinstance(child, (Tag, TagifiedTag)):
         return "data-shinychat-react" in child.attrs
     return False
 
@@ -32,15 +39,15 @@ def split_html_islands(content: TagChild | TagList) -> list[TagChild]:
 
     Returns a list of TagChild items ready to be serialized.
     """
-    if isinstance(content, TagList):
+    if isinstance(content, (TagList, TagifiedTagList)):
         children = list(content)
-    elif isinstance(content, Tag):
+    elif isinstance(content, (Tag, TagifiedTag)):
         if _has_react_attr(content):
             return [content]
         return [Tag("shinychat-raw-html", content)]
     elif isinstance(content, Tagifiable):
         resolved = content.tagify()
-        if isinstance(resolved, Tag) and _has_react_attr(resolved):
+        if isinstance(resolved, (Tag, TagifiedTag)) and _has_react_attr(resolved):
             return [resolved]
         return [Tag("shinychat-raw-html", content)]
     else:

--- a/pkg-py/tests/pytest/test_chat.py
+++ b/pkg-py/tests/pytest/test_chat.py
@@ -36,6 +36,9 @@ class _MockSession:
     def on_ended(self, callback: object) -> None:
         pass
 
+    def on_destroy(self, callback: object) -> None:
+        pass
+
     def _increment_busy_count(self) -> None:
         pass
 

--- a/pkg-py/tests/pytest/test_html_islands.py
+++ b/pkg-py/tests/pytest/test_html_islands.py
@@ -114,7 +114,7 @@ def test_tagifiable_without_react_attr_wrapped():
 
     class FakeWidget(Tagifiable):
         def tagify(self):
-            return div("widget content")
+            return div("widget content").tagify()
 
     result = split_html_islands(FakeWidget())
     rendered = TagList(result).render()["html"]
@@ -132,7 +132,7 @@ def test_tagifiable_in_taglist_splits_correctly():
                 "shiny-tool-result",
                 data_shinychat_react=True,
                 request_id="test-456",
-            )
+            ).tagify()
 
     tl = TagList(div("before"), FakeToolResult(), div("after"))
     result = split_html_islands(tl)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,6 @@ dev = [
     {include-group = "test"},
 ]
 
-[tool.uv]
-upgrade-package = ["shinychat"]
-
-# shiny>=1.6.2 depends on `shinychat` (this project), which uv can't
-# satisfy through the workspace. See `py-install-pr-shiny` in the
-# Makefile for the post-sync workaround.
-
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "pkg-py/README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
-    "htmltools>=0.6.0",
+    "htmltools>=0.7.0",
     "shiny>=1.4.0",
 ]
 dynamic = ["version"]
@@ -58,6 +58,10 @@ dev = [
 
 [tool.uv]
 upgrade-package = ["shinychat"]
+
+# shiny>=1.6.2 depends on `shinychat` (this project), which uv can't
+# satisfy through the workspace. See `py-install-pr-shiny` in the
+# Makefile for the post-sync workaround.
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]


### PR DESCRIPTION
True patch release on top of `py/v0.3.1` — only the htmltools 0.7.0 / Tagified contract fix is included, none of the post-v0.3.1 feature work currently sitting on `main`.

## Summary
- Cherry-picks #226 (`fix: align custom .tagify() annotations with htmltools Tagified contract`) and #229 (`chore(py): drop unnecessary shiny post-sync workaround from #226`) on top of the `py/v0.3.1` tag.
- Bumps the `htmltools` floor from `>=0.6.0` to `>=0.7.0` in `pyproject.toml`, since the fix uses the new `Tagified` type alias.
- Adds the `Release v0.3.2` changelog entry mirroring the one already drafted on `schloerke/changelog-release-prep`.
- One small conflict in `_chat_bookmark.py` was resolved by keeping the v0.3.1 import structure and swapping `TagChild` → `Tagified` as a runtime import (the `TYPE_CHECKING` guard from #226 assumed an earlier refactor that hadn't landed at v0.3.1; with the hard floor at htmltools 0.7.0 the guard is no longer needed).

## Verification
- `git diff py/v0.3.1..HEAD --stat` shows 7 files, +39/−18 lines — only the tagify-related changes.
- After merge, tag the merge commit as `py/v0.3.2` and release.