### PR TITLE
chore(pkg-py): migrate storage-layer types from TypedDicts/dataclasses to Pydantic models

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -29,6 +29,7 @@ from htmltools import (
     TagList,
     css,
 )
+from pydantic import ValidationError
 
 from . import _utils
 from ._chat_bookmark import (
@@ -64,7 +65,6 @@ from ._chat_tokenizer import (
     get_default_tokenizer,
 )
 from ._chat_types import (
-    BookmarkMessageDict,
     ChatAction,
     ChatGreeting,
     ChatMessage,
@@ -73,8 +73,7 @@ from ._chat_types import (
     ContentSegment,
     GreetingOptions,
     MessagePayload,
-    Role,
-    StoredContentSegment,
+    SerializedDep,
     StoredMessage,
     chat_greeting,
 )
@@ -935,7 +934,7 @@ class Chat:
                     # _transform_message returns a single-segment StoredMessage, so all stream
                     # deps belong on segments[0].
                     if serialized_deps and msg.segments:
-                        msg.segments[0]["html_deps"] = serialized_deps
+                        msg.segments[0].html_deps = serialized_deps
                     self._store_message(msg)
             elif chunk == "end":
                 # When `operation="append"`, msg.content is just a chunk, but we must
@@ -1144,17 +1143,14 @@ class Chat:
         # travels as raw text paired with content_type="thinking", and the
         # client builds the thinking block from that type. StoredMessage.content
         # is the flat-string form that re-wraps thinking in tags instead.
-        content = "".join(s["content"] for s in message.segments)
+        content = "".join(s.content for s in message.segments)
         content_type = (
-            message.segments[-1]["content_type"] if message.segments else "markdown"
+            message.segments[-1].content_type if message.segments else "markdown"
         )
 
         msg_payload: MessagePayload = {
             "role": message.role,
-            "segments": [
-                {"content": s["content"], "content_type": s["content_type"]}
-                for s in message.segments
-            ],
+            "segments": message.wire_segments(),
         }
         if icon is not None:
             msg_payload["icon"] = str(icon)
@@ -1184,28 +1180,22 @@ class Chat:
             action = {"type": "message", "message": msg_payload}
             await self._send_action(action, message.html_deps)
 
-    def _messages_for_bookmark(self) -> list[BookmarkMessageDict]:
+    def _messages_for_bookmark(self) -> list[dict[str, Any]]:
         from shiny import reactive
 
         with reactive.isolate():
             messages = self._messages()
 
-        return [
-            BookmarkMessageDict(role=m.role, segments=m.segments)
-            for m in messages
-        ]
+        return [m.model_dump(exclude_none=True) for m in messages]
 
     async def _restore_bookmark_message(self, message_dict: Any) -> None:
-        # Typed Any: bookmark state is deserialized JSON, so `segments` may be
-        # absent in bookmarks written by an incompatible/older shinychat version.
-        if "segments" not in message_dict:
+        try:
+            stored = StoredMessage.model_validate(message_dict)
+        except ValidationError as e:
             raise ValueError(
-                "Cannot restore bookmark message: missing 'segments' key "
+                "Cannot restore bookmark message: invalid or missing fields "
                 "(bookmark likely written by an incompatible shinychat version)."
-            )
-        segments: list[StoredContentSegment] = message_dict["segments"]
-        role: Role = message_dict.get("role", "assistant")
-        stored = StoredMessage(role=role, segments=segments)
+            ) from e
         self._store_message(stored)
         await self._send_append_message(stored)
 
@@ -1348,13 +1338,13 @@ class Chat:
 
     def _serialize_html_deps(
         self, deps: list[HTMLDependency] | None
-    ) -> list[dict[str, object]] | None:
+    ) -> list[SerializedDep] | None:
         if not deps:
             return None
         if self._session is None:
             return None
         processed = self._session._process_ui(TagList(*deps))
-        return cast(list[dict[str, object]], processed["deps"])
+        return cast(list[SerializedDep], processed["deps"])
 
     def _as_stored_message(
         self,
@@ -1762,7 +1752,7 @@ class Chat:
     async def _send_action(
         self,
         action: ChatAction,
-        html_deps: list[dict[str, object]] | None = None,
+        html_deps: list[SerializedDep] | None = None,
     ):
         envelope: dict[str, object] = {
             "id": self.id,

--- a/pkg-py/src/shinychat/_chat_segments.py
+++ b/pkg-py/src/shinychat/_chat_segments.py
@@ -4,7 +4,12 @@ from typing import Callable
 
 from htmltools import HTMLDependency
 
-from ._chat_types import ContentSegment, ContentType, StoredContentSegment
+from ._chat_types import (
+    ContentSegment,
+    ContentType,
+    SerializedDep,
+    StoredSegment,
+)
 
 
 def segments_content(segments: list[ContentSegment]) -> str:
@@ -21,7 +26,11 @@ def segments_deps(segments: list[ContentSegment]) -> list[HTMLDependency]:
 
 def copy_segments(segments: list[ContentSegment]) -> list[ContentSegment]:
     return [
-        ContentSegment(s.content, s.content_type, list(s.html_deps) if s.html_deps else None)
+        ContentSegment(
+            content=s.content,
+            content_type=s.content_type,
+            html_deps=list(s.html_deps) if s.html_deps else None,
+        )
         for s in segments
     ]
 
@@ -48,22 +57,24 @@ def append_to_segments(
                 segments[-1].html_deps = []
             segments[-1].html_deps.extend(deps)
     else:
-        deps_copy = list(deps) if deps else None
-        segments.append(ContentSegment(content, content_type, deps_copy))
+        segments.append(
+            ContentSegment(
+                content=content,
+                content_type=content_type,
+                html_deps=list(deps) if deps else None,
+            )
+        )
 
 
 def serialize_segments(
     segments: list[ContentSegment],
-    serialize_deps: Callable[[list[HTMLDependency] | None], list[dict[str, object]] | None],
-) -> list[StoredContentSegment]:
-    result: list[StoredContentSegment] = []
-    for seg in segments:
-        stored_seg = StoredContentSegment(
+    serialize_deps: Callable[[list[HTMLDependency] | None], list[SerializedDep] | None],
+) -> list[StoredSegment]:
+    return [
+        StoredSegment(
             content=seg.content,
             content_type=seg.content_type,
+            html_deps=serialize_deps(seg.html_deps or None),
         )
-        serialized_deps = serialize_deps(seg.html_deps)
-        if serialized_deps:
-            stored_seg["html_deps"] = serialized_deps
-        result.append(stored_seg)
-    return result
+        for seg in segments
+    ]

--- a/pkg-py/src/shinychat/_chat_types.py
+++ b/pkg-py/src/shinychat/_chat_types.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import AsyncIterable, Literal, Union
 
 from htmltools import HTML, HTMLDependency, Tag, TagChild, TagList
+from pydantic import BaseModel
 
 from ._html_islands import split_html_islands
 from ._typing_extensions import NotRequired, TypedDict
 
 Role = Literal["assistant", "user", "system"]
+
+SerializedDep = dict[str, object]
 
 # ---------------------------------------------------------------------------
 # Wire-format types (mirrors js/src/transport/types.ts)
@@ -131,7 +133,7 @@ ChatAction = Union[
 class ShinyChatEnvelope(TypedDict):
     id: str
     action: ChatAction
-    html_deps: NotRequired[list[dict[str, object]]]
+    html_deps: NotRequired[list[SerializedDep]]
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +146,7 @@ class ShinyChatEnvelope(TypedDict):
 class ChatMessageDict(TypedDict):
     content: str
     role: Role
-    html_deps: NotRequired[list[dict[str, object]]]
+    html_deps: NotRequired[list[SerializedDep]]
 
 
 class ChatMessage:
@@ -269,11 +271,9 @@ def chat_greeting(
     )
 
 
-@dataclass
-class ContentSegment:
+class _SegmentBase(BaseModel):
     content: str
     content_type: ContentType
-    html_deps: list[HTMLDependency] | None = None
 
     def __str__(self) -> str:
         return self.stringify(self.content, self.content_type)
@@ -285,41 +285,54 @@ class ContentSegment:
         return content
 
 
-class StoredContentSegment(TypedDict):
-    content: str
-    content_type: ContentType
-    html_deps: NotRequired[list[dict[str, object]]]
+class ContentSegment(_SegmentBase):
+    model_config = {"arbitrary_types_allowed": True}
+
+    html_deps: list[HTMLDependency] | None = None
 
 
-class BookmarkMessageDict(TypedDict):
+class StoredSegment(_SegmentBase):
+    html_deps: list[SerializedDep] | None = None
+
+
+class StoredMessage(BaseModel):
     role: Role
-    segments: list[StoredContentSegment]
-
-
-@dataclass
-class StoredMessage:
-    role: Role
-    segments: list[StoredContentSegment]
+    segments: list[StoredSegment]
 
     @property
     def content(self) -> str:
         return "".join(
-            ContentSegment.stringify(s["content"], s["content_type"])
+            StoredSegment.stringify(s.content, s.content_type)
             for s in self.segments
         )
 
     @property
-    def html_deps(self) -> list[dict[str, object]] | None:
-        deps = [d for s in self.segments for d in (s.get("html_deps") or [])]
+    def html_deps(self) -> list[SerializedDep] | None:
+        deps: list[SerializedDep] = []
+        for s in self.segments:
+            if s.html_deps:
+                deps.extend(s.html_deps)
         return deps or None
+
+    def wire_segments(self) -> list[MessagePayloadSegment]:
+        return [
+            {"content": s.content, "content_type": s.content_type}
+            for s in self.segments
+        ]
 
     @classmethod
     def from_chat_message(
         cls,
         message: ChatMessage,
-        html_deps: list[dict[str, object]] | None = None,
-    ) -> "StoredMessage":
-        seg = StoredContentSegment(content=str(message.content), content_type=message.content_type)
-        if html_deps:
-            seg["html_deps"] = html_deps
-        return StoredMessage(role=message.role, segments=[seg])
+        html_deps: list[SerializedDep] | None = None,
+    ) -> StoredMessage:
+        return cls(
+            role=message.role,
+            segments=[
+                StoredSegment(
+                    content=str(message.content),
+                    content_type=message.content_type,
+                    html_deps=html_deps,
+                )
+            ],
+        )

--- a/pkg-py/tests/pytest/test_chat.py
+++ b/pkg-py/tests/pytest/test_chat.py
@@ -19,8 +19,8 @@ from shinychat._chat_types import (
     ChatMessage,
     ChatMessageDict,
     Role,
-    StoredContentSegment,
     StoredMessage,
+    StoredSegment,
 )
 from shinychat._utils_types import MISSING
 
@@ -733,13 +733,13 @@ def test_as_ollama_message():
 
 
 def test_stored_message_content_joins_segments():
-    from shinychat._chat_types import StoredContentSegment, StoredMessage
+    from shinychat._chat_types import StoredMessage, StoredSegment
 
     msg = StoredMessage(
         role="assistant",
         segments=[
-            StoredContentSegment(content="a ", content_type="markdown"),
-            StoredContentSegment(content="<b>b</b>", content_type="html"),
+            StoredSegment(content="a ", content_type="markdown"),
+            StoredSegment(content="<b>b</b>", content_type="html"),
         ],
     )
     assert msg.content == "a <b>b</b>"
@@ -750,8 +750,8 @@ def test_stored_message_from_chat_message_makes_one_segment():
 
     sm = StoredMessage.from_chat_message(ChatMessage(content="hi", role="assistant"))
     assert len(sm.segments) == 1
-    assert sm.segments[0]["content"] == "hi"
-    assert sm.segments[0]["content_type"] == "markdown"
+    assert sm.segments[0].content == "hi"
+    assert sm.segments[0].content_type == "markdown"
 
 
 def test_stored_message_from_chat_message_preserves_content_type():
@@ -760,11 +760,11 @@ def test_stored_message_from_chat_message_preserves_content_type():
 
     html_msg = ChatMessage(content=HTML("<b>bold</b>"), role="assistant")
     sm_html = StoredMessage.from_chat_message(html_msg)
-    assert sm_html.segments[0]["content_type"] == "html"
+    assert sm_html.segments[0].content_type == "html"
 
     thinking_msg = ChatMessage(content="reasoning", role="assistant", content_type="thinking")
     sm_thinking = StoredMessage.from_chat_message(thinking_msg)
-    assert sm_thinking.segments[0]["content_type"] == "thinking"
+    assert sm_thinking.segments[0].content_type == "thinking"
 
 
 class MyObject:
@@ -824,9 +824,9 @@ def test_stream_thinking_creates_thinking_segment():
 
         run_async(_exercise)
         segs = captured[0].segments
-        assert [s["content_type"] for s in segs] == ["thinking", "markdown"]
-        assert segs[0]["content"] == "reasoning"
-        assert segs[1]["content"] == "answer"
+        assert [s.content_type for s in segs] == ["thinking", "markdown"]
+        assert segs[0].content == "reasoning"
+        assert segs[1].content == "answer"
 
 
 def test_thinking_stream_stores_segment_not_tags():
@@ -851,10 +851,10 @@ def test_thinking_stream_stores_segment_not_tags():
         with reactive.isolate():
             messages = chat._messages()
         segs = messages[0].segments
-        assert [s["content_type"] for s in segs] == ["thinking", "markdown"]
+        assert [s.content_type for s in segs] == ["thinking", "markdown"]
         # Storage keeps raw segment content (no inline tags); only the string
         # `.content` view re-wraps thinking in <thinking> tags.
-        assert "<thinking>" not in segs[0]["content"]
+        assert "<thinking>" not in segs[0].content
 
 
 def test_send_message_payload_has_segments_with_thinking():
@@ -869,8 +869,8 @@ def test_send_message_payload_has_segments_with_thinking():
         stored = StoredMessage(
             role="assistant",
             segments=[
-                StoredContentSegment(content="reasoning", content_type="thinking"),
-                StoredContentSegment(content="answer", content_type="markdown"),
+                StoredSegment(content="reasoning", content_type="thinking"),
+                StoredSegment(content="answer", content_type="markdown"),
             ],
         )
 
@@ -898,8 +898,8 @@ def test_bookmark_roundtrip_thinking_segment():
             StoredMessage(
                 role="assistant",
                 segments=[
-                    StoredContentSegment(content="reasoning", content_type="thinking"),
-                    StoredContentSegment(content="answer", content_type="markdown"),
+                    StoredSegment(content="reasoning", content_type="thinking"),
+                    StoredSegment(content="answer", content_type="markdown"),
                 ],
             )
         )
@@ -915,13 +915,13 @@ def test_bookmark_roundtrip_thinking_segment():
 
 
 def test_stored_message_content_wraps_thinking_in_tags():
-    from shinychat._chat_types import StoredContentSegment, StoredMessage
+    from shinychat._chat_types import StoredMessage, StoredSegment
 
     msg = StoredMessage(
         role="assistant",
         segments=[
-            StoredContentSegment(content="reasoning", content_type="thinking"),
-            StoredContentSegment(content="the answer", content_type="markdown"),
+            StoredSegment(content="reasoning", content_type="thinking"),
+            StoredSegment(content="the answer", content_type="markdown"),
         ],
     )
     assert msg.content == "<thinking>\nreasoning\n</thinking>\n\nthe answer"
@@ -1034,3 +1034,4 @@ def test_streaming_chunk_content_type_follows_segment():
         ]
         assert ("reasoning", "thinking") in chunk_types
         assert ("answer", "markdown") in chunk_types
+


### PR DESCRIPTION
## Summary

The internal types that represent stored chat messages and their content segments (`StoredMessage`, content segments, etc.) were a mix of `TypedDict`s and `@dataclass`es. This worked, but it meant bookmark serialization/deserialization was hand-rolled, dict-style field access (`s["content"]`) was used in some places and attribute access (`s.content`) in others, and there was no validation on data coming in from bookmarks.

This PR migrates those storage-layer types to Pydantic `BaseModel`s.

## What improves

- **Bookmark restore is validated.** Restoring a bookmarked message now goes through `StoredMessage.model_validate()`, so malformed or incompatible bookmark data raises a clear Pydantic `ValidationError` (chained for diagnostics) instead of blowing up at an arbitrary point downstream.
- **Bookmark serialization is `model_dump()`.** The old `BookmarkMessageDict` TypedDict and its manual construction are gone — `StoredMessage` knows how to serialize itself.
- **Uniform attribute access.** Segments are now always accessed as `s.content`, `s.content_type`, `s.html_deps` — no more mixed dict/attribute styles.
- **`SerializedDep` type alias.** `dict[str, object]` appeared in ~8 signatures to represent a serialized HTML dependency. It now has a name (`SerializedDep`), making intent clearer and grep-able.
- **Cleaner segment type hierarchy.** A `_SegmentBase` model holds the shared fields (`content`, `content_type`) and the `stringify` logic. `ContentSegment` (live, holds `HTMLDependency` objects) and `StoredSegment` (serialized, holds `SerializedDep` dicts) both inherit from it, differing only in their `html_deps` type.
- **`wire_segments()` method.** The inline dict-comprehension that built `MessagePayloadSegment` lists for the wire format now lives on `StoredMessage` where it belongs.

## What doesn't change

- Wire format to the JS client is identical.
- `ChatMessage`, `ChatGreeting`, and all the `ChatAction` TypedDicts are untouched — this only affects the *storage* layer.
- No new dependencies (`pydantic` is already a transitive dep via Shiny).