### PR TITLE
fix: exclude control inputs from Shiny bookmarking in chat_app()

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -1905,7 +1905,8 @@ class Chat:
         # Must use `root_session` as the id is already resolved. :-/
         # Using a proxy session would double-encode the proxy-prefix
         root_session = session.root_scope()
-        root_session.bookmark.exclude.append(self.id + "_user_input")
+        for suffix in ("_user_input", "_cancel", "_slash_command", "_greeting_requested"):
+            root_session.bookmark.exclude.append(self.id + suffix)
 
         # ###########
         # Bookmarking

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -159,6 +159,7 @@ chat_app <- function(
   }
 
   server <- function(input, output, session) {
+    shiny::setBookmarkExclude("close_btn")
     chat_mod_server("chat", client)
 
     shiny::observeEvent(input$close_btn, label = "on_close_btn", {

--- a/pkg-r/R/chat_restore.R
+++ b/pkg-r/R/chat_restore.R
@@ -93,7 +93,10 @@ chat_restore <- function(
   excluded_names <- session$getBookmarkExclude()
   id_user_input <- paste0(id, "_user_input")
   to_exclude <- setdiff(
-    paste0(id, c("_user_input", "_cancel", "_slash_command", "_greeting_requested")),
+    paste0(
+      id,
+      c("_user_input", "_cancel", "_slash_command", "_greeting_requested")
+    ),
     excluded_names
   )
   if (length(to_exclude) > 0) {

--- a/pkg-r/R/chat_restore.R
+++ b/pkg-r/R/chat_restore.R
@@ -92,7 +92,10 @@ chat_restore <- function(
   # Exclude works with bookmark names
   excluded_names <- session$getBookmarkExclude()
   id_user_input <- paste0(id, "_user_input")
-  to_exclude <- setdiff(id_user_input, excluded_names)
+  to_exclude <- setdiff(
+    paste0(id, c("_user_input", "_cancel", "_slash_command", "_greeting_requested")),
+    excluded_names
+  )
   if (length(to_exclude) > 0) {
     session$setBookmarkExclude(c(excluded_names, to_exclude))
   }


### PR DESCRIPTION
Fixes #258

## Summary
`chat_app()` and the underlying `chat_restore()` / `enable_bookmarking()` infrastructure were only excluding `{id}_user_input` from Shiny's bookmark state. Several control-only inputs could accidentally leak into the bookmarked URL or server-side state: the close button (`close_btn`) in `chat_app()`, the cancel/stop button (`{id}_cancel`), slash command triggers (`{id}_slash_command`), and the greeting-requested signal (`{id}_greeting_requested`).

The fix adds those four inputs to the exclusion list in all three relevant locations: `chat_restore.R` (R), `chat_app.R` (R), and `_chat.py` (Python).

## Verification
Run a `chat_app()` with `bookmark_store = "url"` and interact with the close button, cancel button, or a slash command. The resulting bookmark URL should contain only the conversation state — not any of those control input values.