### PR TITLE
fix(pkg-r): Hide close button in chat_app() when non-interactive

### DIFF
--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -16,7 +16,7 @@
 
 ## Bug fixes
 
-* `chat_app()` no longer renders a close button or registers a `stopApp()` observer when deployed to a server. Both are now gated on `rlang::is_interactive()`, preventing session crashes in multi-user deployments.
+* `chat_app()` no longer renders a close button or registers a `stopApp()` observer when deployed to a server. Both are now gated on `rlang::is_interactive()`, preventing session crashes in multi-user deployments. (#265)
 
 * The `dismissible` parameter of `chat_greeting()` has been renamed to `persistent` with an inverted value. `dismissible = FALSE` (greeting stays visible) is now `persistent = TRUE`. The old `dismissible` argument still works but warns. (#260)
 

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Bug fixes
 
+* `chat_app()` no longer renders a close button or registers a `stopApp()` observer when deployed to a server. Both are now gated on `rlang::is_interactive()`, preventing session crashes in multi-user deployments.
+
 * The `dismissible` parameter of `chat_greeting()` has been renamed to `persistent` with an inverted value. `dismissible = FALSE` (greeting stays visible) is now `persistent = TRUE`. The old `dismissible` argument still works but warns. (#260)
 
 * Fixed suggestion cards and the greeting overflowing the chat container in narrow spaces such as sidebars. (#255)

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -149,22 +149,25 @@ chat_app <- function(
         height = "100%",
         allow_attachments = allow_attachments
       ),
-      shiny::actionButton(
-        "close_btn",
-        label = "",
-        class = "btn-close",
-        style = "position: fixed; top: 6px; right: 6px;"
-      )
+      if (rlang::is_interactive()) {
+        shiny::actionButton(
+          "close_btn",
+          label = "",
+          class = "btn-close",
+          style = "position: fixed; top: 6px; right: 6px;"
+        )
+      }
     )
   }
 
   server <- function(input, output, session) {
-    shiny::setBookmarkExclude("close_btn")
+    if (rlang::is_interactive()) {
+      shiny::setBookmarkExclude("close_btn")
+      shiny::observeEvent(input$close_btn, label = "on_close_btn", {
+        shiny::stopApp()
+      })
+    }
     chat_mod_server("chat", client)
-
-    shiny::observeEvent(input$close_btn, label = "on_close_btn", {
-      shiny::stopApp()
-    })
   }
 
   shiny::shinyApp(ui, server, ..., enableBookmarking = bookmark_store)


### PR DESCRIPTION
## Summary

`chat_app()` renders a fixed close button that calls `shiny::stopApp()` when clicked. In a deployed app, `stopApp()` crashes the session for all users. This fix gates both the button (UI) and the `observeEvent` (server) on `rlang::is_interactive()`, so neither exists when the app is running in a non-interactive context such as a deployed Shiny app.

## Verification

Run `chat_app(ellmer::chat_openai())` from an interactive R session — the close button appears in the top-right corner and clicking it stops the app as before. In a deployed app the button is absent.