### PR TITLE
build: exclude JS source maps from built distributions

### DIFF
--- a/pkg-r/.Rbuildignore
+++ b/pkg-r/.Rbuildignore
@@ -15,3 +15,4 @@
 ^revdep$
 ^shiny_bookmarks$
 ^vignettes/articles$
+^inst/lib/shiny/.*\.map$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build]
 skip-excluded-dirs = true
+# Source maps are kept in the source tree (and editable installs) for local
+# debugging, but excluded from built distributions to keep package size down.
+exclude = ["*.map"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["pkg-py/src/shinychat"]


### PR DESCRIPTION
The 5MB `shinychat.js.map` pushed the R package over CRAN size limits.

This excludes `*.map` files from the built distributions:
- **R**: via `.Rbuildignore` (drops the package tarball to ~793K)
- **Python**: via hatchling's `exclude` in `pyproject.toml`

Source maps remain in the source tree, so they stay available for `devtools::load_all()` and editable Python installs.