### PR TITLE
fix(pkg-py): cancel button broken when Chat is inside a Shiny module

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -472,6 +472,7 @@ class Chat:
     ) -> None:
         from chatlas import StreamController
         from shiny import reactive
+        from shiny.module import ResolvedId
         from shiny.session import session_context
 
         from ._chat_client import ChatClient
@@ -483,7 +484,7 @@ class Chat:
         self.client = chat_client
 
         controller = StreamController()
-        cancel_input_id = f"{self.id}_cancel"
+        cancel_input_id = ResolvedId(f"{self.id}_cancel")
 
         # Match the rest of `__init__`: create these effects under the chat's
         # own session so they attach correctly even when `Chat(...)` is

--- a/pkg-py/tests/playwright/chat/auto_cancel_core/app.py
+++ b/pkg-py/tests/playwright/chat/auto_cancel_core/app.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import chatlas
-from shiny import App, Inputs, Outputs, Session, reactive, render, ui
+from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
 from shinychat import Chat, chat_ui
 
 
@@ -62,10 +62,23 @@ class SlowChatClient:
         self._turns = state.get("turns", [])
 
 
+@module.ui
+def chat_mod_ui():
+    return chat_ui(id="chat")
+
+
+@module.server
+def chat_mod_server(input: Inputs, output: Outputs, session: Session) -> None:
+    del input, output, session
+    Chat("chat", client=SlowChatClient())  # type: ignore[arg-type]
+
+
 # Note: `enable_cancel=True` is intentionally omitted here. Passing a
 # `client=` to `Chat` should auto-enable the stop button via a server message.
+# The chat lives inside a module ("mod") to exercise ResolvedId handling in
+# _setup_client — the bug this test guards against only manifests in modules.
 app_ui = ui.page_fillable(
-    chat_ui("chat"),
+    chat_mod_ui("mod"),
     ui.output_code("cancel_requested"),
 )
 
@@ -74,9 +87,8 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
     del input, output, session
     cancel_requested_value = reactive.Value(False)
     ObservableStreamController.cancel_requested = cancel_requested_value
-    client = SlowChatClient()
 
-    Chat("chat", client=client)  # type: ignore[arg-type]
+    chat_mod_server("mod")
 
     @render.code
     def cancel_requested() -> str:

--- a/pkg-py/tests/playwright/chat/auto_cancel_core/test_chat_auto_cancel_core.py
+++ b/pkg-py/tests/playwright/chat/auto_cancel_core/test_chat_auto_cancel_core.py
@@ -9,7 +9,7 @@ def test_auto_chat_cancel_uses_stream_controller(
 ) -> None:
     page.goto(local_app.url)
 
-    chat = ChatController(page, "chat")
+    chat = ChatController(page, "mod-chat")
     cancel_requested = controller.OutputCode(page, "cancel_requested")
 
     expect(chat.loc).to_be_visible(timeout=30_000)


### PR DESCRIPTION
## What broke

The stop/cancel button had no effect when `Chat` was used inside a Shiny module. Clicking it appeared to work visually, but the `StreamController` was never actually cancelled — the streaming response continued to completion.

## Root cause

`Chat._setup_client` constructs the cancel input ID as `f"{self.id}_cancel"`. `self.id` is a `ResolvedId` (e.g. `"foo-chat"`), but string interpolation strips that type, producing a plain string. When `session.input[plain_string]` is called inside a module session, Shiny tries to apply the module namespace prefix — which both rejects the hyphen in the already-resolved ID (raising `ValueError`) and would double-namespace it even if it didn't.

## Fix

Wrap with `ResolvedId(...)`, matching the pattern already used for `user_input_id` and `_slash_command_id` just above in `__init__`.

## Test

Added `auto_cancel_module` Playwright test that verifies the cancel button fires the `StreamController` when the chat lives inside a module. Confirmed red without the fix, green with it.