### PR TITLE
support new ellmer API for grabbing the model name

### DIFF
--- a/pkg-r/R/chat_history_client.R
+++ b/pkg-r/R/chat_history_client.R
@@ -13,7 +13,7 @@ set_turns_recorded <- function(client, recorded_turns) {
 
 get_client_info <- function(client) {
   provider <- client$get_provider()
-  list(provider = provider@name, model = provider@model)
+  list(provider = provider@name, model = client$get_model())
 }
 
 turn_fallback_markdown <- function(recorded_turn) {

--- a/pkg-r/tests/testthat/apps/history-restore-on-reload/app.R
+++ b/pkg-r/tests/testthat/apps/history-restore-on-reload/app.R
@@ -24,6 +24,7 @@ make_echo_client <- function() {
         model = "echo-test"
       )
     },
+    get_model = function() "echo-test",
     clone = function() make_echo_client()
   )
   class(client) <- c("Chat", "R6")

--- a/pkg-r/tests/testthat/helper-mock-chat.R
+++ b/pkg-r/tests/testthat/helper-mock-chat.R
@@ -20,6 +20,7 @@ mock_chat_client <- function(turns = list()) {
     },
     get_tools = function() list(),
     get_provider = function() mock_provider(),
+    get_model = function() "mock-model",
     clone = function() mock_chat_client(stored_turns),
     set_system_prompt = function(prompt) invisible(NULL),
     set_tools = function(tools) invisible(NULL),
@@ -48,6 +49,7 @@ mock_chat_client <- function(turns = list()) {
   client$get_tools <- function() list()
   client$set_tools <- function(t) invisible(NULL)
   client$get_provider <- function() mock_provider()
+  client$get_model <- function() "mock-model"
   client
 }
 


### PR DESCRIPTION
Related to https://github.com/tidyverse/ellmer/pull/1053. Resolves a warning in the dev version of the package with dev ellmer:

```
Warning: Could not save conversation
Caused by error:
! Can't find property <ellmer::ProviderAnthropic>@model
```

`$get_model()` works for both CRAN and dev ellmer, so don't need any version-specific logic.