### PR TITLE
docs(r): document `FileConversationStore` R6 methods

### DIFF
--- a/pkg-r/R/chat_history_store.R
+++ b/pkg-r/R/chat_history_store.R
@@ -297,6 +297,11 @@ FileConversationStore <- R6::R6Class(
       private$write_state <- list()
     },
 
+    #' @description All conversations in `partition`, newest-first by
+    #'   `updated_at`, read from one `record.json` per conversation directory
+    #'   on disk.
+    #' @param partition A `conversation_partition()`.
+    #' @returns A list of conversation meta lists.
     list = function(partition) {
       key <- partition_key(partition)
       cached <- private$meta_cache[[key]]
@@ -346,6 +351,12 @@ FileConversationStore <- R6::R6Class(
       metas
     },
 
+    #' @description The full conversation record for `id` in `partition`,
+    #'   reassembled from `record.json`, `turns.jsonl`, and `ui.jsonl`.
+    #' @param partition A `conversation_partition()`.
+    #' @param id A conversation id, as found in the `id` field of a
+    #'   conversation meta list.
+    #' @returns The conversation record, or `NULL` if missing.
     get = function(partition, id) {
       cdir <- safe_conv_path(private$partition_dir(partition), id)
       record_file <- file.path(cdir, "record.json")
@@ -427,6 +438,12 @@ FileConversationStore <- R6::R6Class(
       )
     },
 
+    #' @description Upsert `record` into `partition`, appending new turns and
+    #'   UI data to `turns.jsonl`/`ui.jsonl` and rewriting `record.json`.
+    #' @param partition A `conversation_partition()`.
+    #' @param record A conversation record, in the same shape returned by
+    #'   `get()`.
+    #' @returns `NULL`, invisibly.
     put = function(partition, record) {
       key <- partition_key(partition)
       cdir <- safe_conv_path(private$partition_dir(partition), record$id)
@@ -551,6 +568,12 @@ FileConversationStore <- R6::R6Class(
       invisible(NULL)
     },
 
+    #' @description Remove the conversation `id` from `partition` by deleting
+    #'   its directory. Missing ids are a no-op.
+    #' @param partition A `conversation_partition()`.
+    #' @param id A conversation id, as found in the `id` field of a
+    #'   conversation meta list.
+    #' @returns `NULL`, invisibly.
     delete = function(partition, id) {
       key <- partition_key(partition)
       cdir <- safe_conv_path(private$partition_dir(partition), id)

--- a/pkg-r/man/FileConversationStore.Rd
+++ b/pkg-r/man/FileConversationStore.Rd
@@ -51,6 +51,9 @@ File-based conversation storage backend
 \if{html}{\out{<a id="method-FileConversationStore-list"></a>}}
 \if{latex}{\out{\hypertarget{method-FileConversationStore-list}{}}}
 \subsection{\code{FileConversationStore$list()}}{
+  All conversations in \code{partition}, newest-first by
+\code{updated_at}, read from one \code{record.json} per conversation directory
+on disk.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{FileConversationStore$list(partition)}
@@ -63,12 +66,17 @@ File-based conversation storage backend
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    A list of conversation meta lists.
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FileConversationStore-get"></a>}}
 \if{latex}{\out{\hypertarget{method-FileConversationStore-get}{}}}
 \subsection{\code{FileConversationStore$get()}}{
+  The full conversation record for \code{id} in \code{partition},
+reassembled from \code{record.json}, \code{turns.jsonl}, and \code{ui.jsonl}.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{FileConversationStore$get(partition, id)}
@@ -83,12 +91,17 @@ conversation meta list.}
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    The conversation record, or \code{NULL} if missing.
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FileConversationStore-put"></a>}}
 \if{latex}{\out{\hypertarget{method-FileConversationStore-put}{}}}
 \subsection{\code{FileConversationStore$put()}}{
+  Upsert \code{record} into \code{partition}, appending new turns and
+UI data to \code{turns.jsonl}/\code{ui.jsonl} and rewriting \code{record.json}.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{FileConversationStore$put(partition, record)}
@@ -103,12 +116,17 @@ conversation meta list.}
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    \code{NULL}, invisibly.
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FileConversationStore-delete"></a>}}
 \if{latex}{\out{\hypertarget{method-FileConversationStore-delete}{}}}
 \subsection{\code{FileConversationStore$delete()}}{
+  Remove the conversation \code{id} from \code{partition} by deleting
+its directory. Missing ids are a no-op.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{FileConversationStore$delete(partition, id)}
@@ -122,6 +140,9 @@ conversation meta list.}
 conversation meta list.}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    \code{NULL}, invisibly.
   }
 }
 


### PR DESCRIPTION
Fixes undocumented R6 methods warning (list, get, put, delete) surfaced by `devtools::document()`.