### PR TITLE
test(r): fix leaking warnings/messages in history & slash-command tests

### DIFF
--- a/pkg-r/NAMESPACE
+++ b/pkg-r/NAMESPACE
@@ -28,8 +28,15 @@ export(output_markdown_stream)
 export(tool_result_display)
 export(update_chat_user_input)
 if (getRversion() < "4.3.0") importFrom("S7", "@")
-import(S7)
 import(rlang)
+importFrom(S7,
+  "method<-",
+  S7_dispatch,
+  S7_inherits,
+  method,
+  new_generic,
+  new_property
+)
 importFrom(coro,async)
 importFrom(htmltools,
   HTML,

--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -614,6 +614,9 @@ HistoryController <- R6::R6Class(
 #'   `"none"` disables automatic restore entirely.
 #' @param store Storage backend: `"auto"` (default: memory in dev, file in
 #'   production), `"memory"`, `"file"`, or a [ConversationStore] R6 instance.
+#'   `"auto"` emits a once-per-session message announcing which backend was
+#'   chosen; set `options(shinychat.history_options.store_auto.quiet = TRUE)`
+#'   to silence it.
 #' @param scope Storage namespace for conversations. A string, a
 #'   `function(session)` returning a string, or `NULL` (default: uses
 #'   `session$user` if authenticated, otherwise a per-browser token).

--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -639,6 +639,11 @@ history_options <- function(
   max_store_mb = 100
 ) {
   restore_mode <- match.arg(restore_mode)
+  if (!is.function(title) && !is.null(title) && !identical(title, "auto")) {
+    rlang::abort(
+      '`title` must be "auto", a function(recorded_turns), or NULL.'
+    )
+  }
   structure(
     list(
       restore_mode = restore_mode,

--- a/pkg-r/R/chat_history_store.R
+++ b/pkg-r/R/chat_history_store.R
@@ -585,22 +585,39 @@ resolve_store <- function(store) {
   }
 
   store <- match.arg(store, c("auto", "memory", "file"))
+  quiet <- getOption(
+    "shinychat.history_options.store_auto.quiet",
+    default = identical(Sys.getenv("TESTTHAT"), "true")
+  )
+  quiet_hint <- c(
+    i = "Set {.code options(shinychat.history_options.store_auto.quiet = TRUE)} to silence this message."
+  )
   switch(
     store,
     auto = {
       if (shiny::in_devmode()) {
-        cli::cli_inform(
-          "Chat history: using in-memory storage (dev mode). History is lost on restart. To persist across restarts, use {.code history_options(store = \"file\")}.",
-          .frequency = "once",
-          .frequency_id = "shinychat_store_auto_memory"
-        )
+        if (!quiet) {
+          cli::cli_inform(
+            c(
+              "Chat history: using in-memory storage (dev mode). History is lost on restart. To persist across restarts, use {.code history_options(store = \"file\")}.",
+              quiet_hint
+            ),
+            .frequency = "once",
+            .frequency_id = "shinychat_store_auto_memory"
+          )
+        }
         auto_dev_memory_store()
       } else {
-        cli::cli_inform(
-          "Chat history: using file-based storage. To use in-memory storage instead, use {.code history_options(store = \"memory\")}.",
-          .frequency = "once",
-          .frequency_id = "shinychat_store_auto_file"
-        )
+        if (!quiet) {
+          cli::cli_inform(
+            c(
+              "Chat history: using file-based storage. To use in-memory storage instead, use {.code history_options(store = \"memory\")}.",
+              quiet_hint
+            ),
+            .frequency = "once",
+            .frequency_id = "shinychat_store_auto_file"
+          )
+        }
         FileConversationStore$new()
       }
     },

--- a/pkg-r/R/client_state.R
+++ b/pkg-r/R/client_state.R
@@ -6,7 +6,7 @@ client_set_ui <- new_generic(
   "client_set_ui",
   "client",
   function(client, ..., id) {
-    S7::S7_dispatch()
+    S7_dispatch()
   }
 )
 

--- a/pkg-r/R/content-slash-command.R
+++ b/pkg-r/R/content-slash-command.R
@@ -61,7 +61,7 @@ ContentSlashCommand <- S7::new_class(
   parent = ellmer::ContentText,
   properties = list(
     command = new_property(
-      class_character,
+      S7::class_character,
       validator = function(value) {
         if (length(value) != 1 || is.na(value)) {
           "must be a single non-missing string."
@@ -69,7 +69,7 @@ ContentSlashCommand <- S7::new_class(
       }
     ),
     user_text = new_property(
-      class_character,
+      S7::class_character,
       default = "",
       validator = function(value) {
         if (length(value) != 1 || is.na(value)) {

--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -119,15 +119,15 @@ opt_shinychat_tool_display <- function() {
 #'   `chat_ui()`.
 #'
 #' @export
-contents_shinychat <- S7::new_generic(
+contents_shinychat <- new_generic(
   "contents_shinychat",
   "content",
   function(content) {
-    S7::S7_dispatch()
+    S7_dispatch()
   }
 )
 
-S7::method(contents_shinychat, ellmer::Content) <- function(content) {
+method(contents_shinychat, ellmer::Content) <- function(content) {
   # Fall back to html or markdown
   html <- ellmer::contents_html(content)
   if (!is.null(html)) {
@@ -137,15 +137,15 @@ S7::method(contents_shinychat, ellmer::Content) <- function(content) {
   }
 }
 
-S7::method(contents_shinychat, ContentSlashCommand) <- function(content) {
+method(contents_shinychat, ContentSlashCommand) <- function(content) {
   trimws(paste0("/", content@command, " ", content@user_text))
 }
 
-S7::method(contents_shinychat, ellmer::ContentText) <- function(content) {
+method(contents_shinychat, ellmer::ContentText) <- function(content) {
   content@text
 }
 
-S7::method(contents_shinychat, ellmer::ContentThinking) <- function(content) {
+method(contents_shinychat, ellmer::ContentThinking) <- function(content) {
   structure(content@thinking, class = "shinychat_thinking")
 }
 
@@ -185,7 +185,7 @@ shinychat_tool_annotations <- function(tool) {
 
 # A `contents_shinychat()` method on a `ContentToolResult` subclass may
 # return arbitrary tags instead of shinychat's own tool card (see the
-# `S7::method(contents_shinychat, ...)` examples above). That leaves no
+# `method(contents_shinychat, ...)` examples above). That leaves no
 # `<shiny-tool-result>` element in the transcript at all, so the condensed
 # tool view — which derives "this call finished" from that element's
 # presence — has nothing to key off of and the request row spins forever.
@@ -201,7 +201,7 @@ shinychat_tool_annotations <- function(tool) {
 # custom UI and gets wrapped.
 wrap_custom_tool_result <- function(content, msg) {
   if (
-    !S7::S7_inherits(content, ellmer::ContentToolResult) ||
+    !S7_inherits(content, ellmer::ContentToolResult) ||
       inherits(msg, "shinychat_tool_card") ||
       is.null(msg)
   ) {
@@ -260,7 +260,7 @@ wrap_custom_tool_result <- function(content, msg) {
 # idempotent, since a wrapped result *is* a `shinychat_tool_card` and so fails
 # the wrap's own guard on a second pass.
 contents_shinychat_wrapped <- function(content) {
-  if (!S7::S7_inherits(content, ellmer::Content)) {
+  if (!S7_inherits(content, ellmer::Content)) {
     return(content)
   }
 
@@ -330,7 +330,7 @@ knit_print.shinychat_tool_card <- function(x, ...) {
   knitr::knit_print(as.tags(x))
 }
 
-S7::method(contents_shinychat, ellmer::ContentToolRequest) <- function(
+method(contents_shinychat, ellmer::ContentToolRequest) <- function(
   content
 ) {
   if (opt_shinychat_tool_display() == "none") {
@@ -355,7 +355,7 @@ S7::method(contents_shinychat, ellmer::ContentToolRequest) <- function(
   )
 }
 
-S7::method(contents_shinychat, ellmer::ContentToolResult) <- function(content) {
+method(contents_shinychat, ellmer::ContentToolResult) <- function(content) {
   if (opt_shinychat_tool_display() == "none") {
     return(NULL)
   }
@@ -688,31 +688,31 @@ tool_string_value <- function(x) {
 }
 
 is_content_extra <- function(x) {
-  is_content_image(x) || S7::S7_inherits(x, ellmer::ContentPDF)
+  is_content_image(x) || S7_inherits(x, ellmer::ContentPDF)
 }
 
 is_content_image <- function(x) {
-  S7::S7_inherits(x, ellmer::ContentImage)
+  S7_inherits(x, ellmer::ContentImage)
 }
 
 as_content_extra_item <- function(x) {
-  if (S7::S7_inherits(x, ellmer::ContentImageRemote)) {
+  if (S7_inherits(x, ellmer::ContentImageRemote)) {
     list(type = "image", src = x@url)
-  } else if (S7::S7_inherits(x, ellmer::ContentImageInline)) {
+  } else if (S7_inherits(x, ellmer::ContentImageInline)) {
     list(type = "image", src = paste0("data:", x@type, ";base64,", x@data))
-  } else if (S7::S7_inherits(x, ellmer::ContentPDF)) {
+  } else if (S7_inherits(x, ellmer::ContentPDF)) {
     list(type = "pdf", filename = x@filename %||% "document.pdf")
   }
 }
 
 is_content <- function(x) {
-  S7::S7_inherits(x, ellmer::Content)
+  S7_inherits(x, ellmer::Content)
 }
 
 as_content_extra_item_or_text <- function(x) {
   if (is_content_extra(x)) {
     as_content_extra_item(x)
-  } else if (S7::S7_inherits(x, ellmer::ContentText)) {
+  } else if (S7_inherits(x, ellmer::ContentText)) {
     list(type = "text", value = x@text, value_type = "markdown")
   } else {
     list(type = "text", value = as.character(x), value_type = "markdown")
@@ -756,7 +756,7 @@ tool_default_display <- function(content) {
   list(value = tool_string_value(content), value_type = "code")
 }
 
-S7::method(contents_shinychat, ellmer::Turn) <- function(content) {
+method(contents_shinychat, ellmer::Turn) <- function(content) {
   # Process all contents in the turn, filtering out empty results.
   #
   # Wrapped, for the same reason as `merge_ellmer_turn_group()`: converting a
@@ -769,7 +769,7 @@ S7::method(contents_shinychat, ellmer::Turn) <- function(content) {
 ellmer_turn_effective_role <- function(turn) {
   contents <- turn@contents
   is_tool_result_only <- length(contents) > 0 &&
-    every(contents, S7::S7_inherits, ellmer::ContentToolResult)
+    every(contents, S7_inherits, ellmer::ContentToolResult)
   if (is_tool_result_only) "assistant" else turn@role
 }
 
@@ -796,7 +796,7 @@ merge_ellmer_turn_group <- function(group, tools) {
   contents <- unlist(
     lapply(group, function(turn) {
       turn_contents <- map(turn@contents, function(x) {
-        if (!S7::S7_inherits(x, ellmer::ContentToolResult)) {
+        if (!S7_inherits(x, ellmer::ContentToolResult)) {
           return(x)
         }
         if (!is.null(x@request@tool)) {
@@ -834,7 +834,7 @@ merge_ellmer_turn_group <- function(group, tools) {
   list(role = role, content = content)
 }
 
-S7::method(contents_shinychat, S7::new_S3_class(c("Chat", "R6"))) <- function(
+method(contents_shinychat, S7::new_S3_class(c("Chat", "R6"))) <- function(
   content
 ) {
   tools <- content$get_tools()

--- a/pkg-r/R/shinychat-package.R
+++ b/pkg-r/R/shinychat-package.R
@@ -3,7 +3,7 @@
 
 ## usethis namespace: start
 #' @import rlang
-#' @import S7
+#' @importFrom S7 new_generic method "method<-" new_property S7_dispatch S7_inherits
 #' @importFrom coro async
 #' @importFrom htmltools as.tags
 #' @importFrom htmltools tag css HTML

--- a/pkg-r/man/history_options.Rd
+++ b/pkg-r/man/history_options.Rd
@@ -27,7 +27,10 @@ conversation's bookmark URL if one exists.
 \code{"none"} disables automatic restore entirely.}
 
 \item{store}{Storage backend: \code{"auto"} (default: memory in dev, file in
-production), \code{"memory"}, \code{"file"}, or a \link{ConversationStore} R6 instance.}
+production), \code{"memory"}, \code{"file"}, or a \link{ConversationStore} R6 instance.
+\code{"auto"} emits a once-per-session message announcing which backend was
+chosen; set \code{options(shinychat.history_options.store_auto.quiet = TRUE)}
+to silence it.}
 
 \item{scope}{Storage namespace for conversations. A string, a
 \verb{function(session)} returning a string, or \code{NULL} (default: uses

--- a/pkg-r/tests/testthat/_snaps/chat_history_store.md
+++ b/pkg-r/tests/testthat/_snaps/chat_history_store.md
@@ -1,0 +1,18 @@
+# resolve_store('auto') announces the dev-mode backend once per session
+
+    Code
+      invisible(resolve_store("auto"))
+    Message
+      Chat history: using in-memory storage (dev mode). History is lost on restart. To persist across restarts, use `history_options(store = "file")`.
+      i Set `options(shinychat.history_options.store_auto.quiet = TRUE)` to silence this message.
+      This message is displayed once per session.
+
+# resolve_store('auto') announces the file-based backend once per session
+
+    Code
+      invisible(resolve_store("auto"))
+    Message
+      Chat history: using file-based storage. To use in-memory storage instead, use `history_options(store = "memory")`.
+      i Set `options(shinychat.history_options.store_auto.quiet = TRUE)` to silence this message.
+      This message is displayed once per session.
+

--- a/pkg-r/tests/testthat/test-chat.R
+++ b/pkg-r/tests/testthat/test-chat.R
@@ -244,6 +244,56 @@ test_that("chat_server handles string user_input values", {
   )
 })
 
+test_that("chat_server warns when bookmark_on_input is used", {
+  local_mocked_bindings(
+    chat_restore = function(...) invisible(NULL),
+    send_chat_action = function(...) invisible(NULL)
+  )
+
+  client <- structure(list(), class = "Chat")
+
+  shiny::testServer(
+    function(input, output, session) {
+      lifecycle::expect_deprecated(
+        chat_server(
+          "chat",
+          client,
+          history = FALSE,
+          bookmark_on_input = TRUE,
+          session = session
+        ),
+        "bookmark_on_input"
+      )
+    },
+    {}
+  )
+})
+
+test_that("chat_server warns when bookmark_on_response is used", {
+  local_mocked_bindings(
+    chat_restore = function(...) invisible(NULL),
+    send_chat_action = function(...) invisible(NULL)
+  )
+
+  client <- structure(list(), class = "Chat")
+
+  shiny::testServer(
+    function(input, output, session) {
+      lifecycle::expect_deprecated(
+        chat_server(
+          "chat",
+          client,
+          history = FALSE,
+          bookmark_on_response = TRUE,
+          session = session
+        ),
+        "bookmark_on_response"
+      )
+    },
+    {}
+  )
+})
+
 test_that("chat_append_message() emits segment payloads incl. thinking", {
   captured <- list()
   local_mocked_bindings(

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -353,7 +353,7 @@ test_that("on_response_saved fires on every response", {
   ctrl <- HistoryController$new(
     chat_id = "chat",
     client = client,
-    options = history_options(store = store, title = "fallback"),
+    options = history_options(store = store, title = NULL),
     session = session
   )
   ctrl$partition <- conversation_partition("chat", "test-user")
@@ -380,7 +380,7 @@ test_that("on_pre_switch returning TRUE skips the in-session swap", {
   ctrl <- HistoryController$new(
     chat_id = "chat",
     client = client,
-    options = history_options(store = store, title = "fallback"),
+    options = history_options(store = store, title = NULL),
     session = session
   )
   ctrl$partition <- conversation_partition("chat", "test-user")
@@ -416,7 +416,7 @@ test_that("on_pre_switch returning FALSE allows the in-session swap", {
   ctrl <- HistoryController$new(
     chat_id = "chat",
     client = client,
-    options = history_options(store = store, title = "fallback"),
+    options = history_options(store = store, title = NULL),
     session = session
   )
   ctrl$partition <- conversation_partition("chat", "test-user")
@@ -443,7 +443,7 @@ test_that("switch_to() raises on a nonexistent conversation id", {
   ctrl <- HistoryController$new(
     chat_id = "chat",
     client = client,
-    options = history_options(store = store, title = "fallback"),
+    options = history_options(store = store, title = NULL),
     session = session
   )
   ctrl$partition <- conversation_partition("chat", "test-user")
@@ -1021,7 +1021,7 @@ test_that("on_evict fires before store$delete in evict_one and delete", {
   ctrl <- HistoryController$new(
     chat_id = "chat",
     client = client,
-    options = history_options(store = store, title = "fallback"),
+    options = history_options(store = store, title = NULL),
     session = session
   )
   ctrl$partition <- conversation_partition("chat", "test-user")

--- a/pkg-r/tests/testthat/test-chat_history_store.R
+++ b/pkg-r/tests/testthat/test-chat_history_store.R
@@ -114,7 +114,10 @@ test_that("InMemoryConversationStore partition keys avoid delimiter collisions",
 })
 
 test_that("resolve_store('auto') in dev mode reuses one process memory store", {
-  withr::local_options(shiny.devmode = TRUE)
+  withr::local_options(
+    shiny.devmode = TRUE,
+    shinychat.history_options.store_auto.quiet = TRUE
+  )
   withr::local_envvar(TESTTHAT = "false")
 
   store1 <- resolve_store("auto")
@@ -122,6 +125,36 @@ test_that("resolve_store('auto') in dev mode reuses one process memory store", {
 
   expect_true(inherits(store1, "InMemoryConversationStore"))
   expect_true(identical(store1, store2))
+})
+
+test_that("resolve_store('auto') announces the dev-mode backend once per session", {
+  withr::local_options(
+    shiny.devmode = TRUE,
+    shinychat.history_options.store_auto.quiet = FALSE
+  )
+  withr::local_envvar(TESTTHAT = "false")
+  rlang::reset_message_verbosity("shinychat_store_auto_memory")
+
+  expect_snapshot(invisible(resolve_store("auto")))
+  expect_no_message(resolve_store("auto"))
+})
+
+test_that("resolve_store('auto') announces the file-based backend once per session", {
+  withr::local_options(
+    shiny.devmode = FALSE,
+    shinychat.history_options.store_auto.quiet = FALSE
+  )
+  rlang::reset_message_verbosity("shinychat_store_auto_file")
+
+  expect_snapshot(invisible(resolve_store("auto")))
+  expect_no_message(resolve_store("auto"))
+})
+
+test_that("resolve_store('auto') is quiet by default under testthat", {
+  withr::local_options(shiny.devmode = FALSE)
+  rlang::reset_message_verbosity("shinychat_store_auto_file")
+
+  expect_no_message(resolve_store("auto"))
 })
 
 test_that("resolve_store('memory') returns a fresh memory store", {

--- a/pkg-r/tests/testthat/test-chat_history_title.R
+++ b/pkg-r/tests/testthat/test-chat_history_title.R
@@ -55,3 +55,14 @@ test_that("fallback_title() truncates long messages", {
 test_that("fallback_title() returns 'New chat' for empty turns", {
   expect_equal(fallback_title(list()), "New chat")
 })
+
+test_that("history_options() accepts 'auto', a function, or NULL for title", {
+  expect_no_error(history_options(title = "auto"))
+  expect_no_error(history_options(title = function(recorded_turns) "Title"))
+  expect_no_error(history_options(title = NULL))
+})
+
+test_that("history_options() errors on unrecognized title values", {
+  expect_error(history_options(title = "fallback"), "auto")
+  expect_error(history_options(title = TRUE), "auto")
+})

--- a/pkg-r/tests/testthat/test-slash-commands.R
+++ b/pkg-r/tests/testthat/test-slash-commands.R
@@ -24,8 +24,7 @@ test_that("chat_server slash_command supports zero-argument handlers", {
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       session$returned$slash_command(
@@ -55,8 +54,7 @@ test_that("chat_server slash_command rejects handlers with more than one paramet
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       expect_error(
@@ -81,8 +79,7 @@ test_that("chat_server slash_command errors on duplicate name by default", {
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       session$returned$slash_command("greet", "Say hello", function() NULL)
@@ -106,8 +103,7 @@ test_that("chat_server slash_command removal unregisters the command", {
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       remove <- session$returned$slash_command(
@@ -155,8 +151,7 @@ test_that("chat_server slash_command allows overwrite with force = TRUE", {
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       session$returned$slash_command(
@@ -190,8 +185,7 @@ test_that("chat_server slash_command echo defaults to handler presence", {
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       session$returned$slash_command(
@@ -223,8 +217,7 @@ test_that("chat_server slash_command echo can be set explicitly", {
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       session$returned$slash_command(
@@ -252,8 +245,7 @@ test_that("chat_server slash_command rejects a non-function, non-NULL handler", 
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       expect_error(
@@ -276,8 +268,7 @@ test_that("chat_server slash_command with NULL handler does not run server-side"
     chat_server_module,
     args = list(
       client = structure(list(), class = "Chat"),
-      bookmark_on_input = FALSE,
-      bookmark_on_response = FALSE
+      history = FALSE
     ),
     {
       # A real handler on a different command, to prove the NULL command does not


### PR DESCRIPTION
## Summary
- Replace deprecated `bookmark_on_input`/`bookmark_on_response` chat_server() args in test-slash-commands.R with `history = FALSE`, and fix an invalid `title = "fallback"` value in test-chat_history.R (falls through to the same LLM auto-titling path as `"auto"`, which errored against the mock client) — both were leaking warnings into `devtools::test()` output.
- Add direct `lifecycle::expect_deprecated()` coverage for the `bookmark_on_input`/`bookmark_on_response` deprecations, so they're tested explicitly rather than as an incidental side effect.
- Add `shinychat.history_options.store_auto.quiet` option to silence the once-per-session "which storage backend was picked" messages from `resolve_store("auto")`, defaulting to quiet under `testthat`. Add snapshot tests pinning the exact message text.
- Narrow `@import S7` to `@importFrom S7 new_generic method "method<-" new_property S7_dispatch S7_inherits` — the blanket import pulled in `S7::validate()`, which shadowed `shiny::validate()` and triggered a "masked" warning on load. Fully qualify `S7::class_character` since it isn't in the new allowlist.

## Test plan
- [x] `devtools::test()` passes with 0 warnings (827 tests)