### PR TITLE
test(py): stabilize bookmark input restore test

### DIFF
--- a/pkg-py/tests/playwright/chat/history_bookmark/test_history_bookmark.py
+++ b/pkg-py/tests/playwright/chat/history_bookmark/test_history_bookmark.py
@@ -19,6 +19,12 @@ def start_conversation(page: Page, text: str) -> None:
     chat.expect_latest_message(f"echo: {text}", timeout=30_000)
 
 
+def expect_filter_state(page: Page, value: str) -> None:
+    expect(page.locator("#filter_state")).to_have_text(
+        f"filter: {value}", timeout=30_000
+    )
+
+
 def test_bookmark_mode_switch_restores_inputs(
     page: Page, local_app: ShinyAppProc
 ) -> None:
@@ -29,7 +35,9 @@ def test_bookmark_mode_switch_restores_inputs(
     # Conversation A: set the input, then chat (the save mints a bookmark
     # capturing the input value).
     controller.InputText(page, "filter_text").set("penguins")
+    expect_filter_state(page, "penguins")
     start_conversation(page, "first question")
+    page.wait_for_url(lambda url: "_state_id_=" in url, timeout=30_000)
 
     # New chat navigates to the bare URL: input back to its default.
     open_drawer(page)


### PR DESCRIPTION
## Why this matters

The Python 3.13 CI job intermittently captured the default filter value before Shiny had processed the test input, causing the bookmark restore assertion to fail even though the feature worked. This change waits for Shiny to acknowledge the input and for the bookmark URL to be minted before switching conversations.

## Verification

- 
🧪 Running tests with pytest
uv run playwright install
uv run pytest pkg-py/tests/playwright/
============================= test session starts ==============================
platform darwin -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/cpsievert/github/shinychat/.worktrees/fix-bookmark-test-sync
configfile: pyproject.toml
plugins: playwright-0.9.0, langsmith-0.10.18, anyio-4.14.2, shiny-1.7.0, base-url-2.1.0
collected 104 items

pkg-py/tests/playwright/MarkdownStream/basic/test_stream_basic.py .      [  0%]
pkg-py/tests/playwright/MarkdownStream/shiny_ui/test_stream_shiny_ui.py . [  1%]
                                                                         [  1%]
pkg-py/tests/playwright/MarkdownStream/stream-result/test_latest_stream_result.py . [  2%]
                                                                         [  2%]
pkg-py/tests/playwright/chat/append_assistant_attachment/test_append_assistant_attachment.py . [  3%]
                                                                         [  3%]
pkg-py/tests/playwright/chat/append_user_msg/test_chat_append_user_msg.py . [  4%]
                                                                         [  4%]
pkg-py/tests/playwright/chat/attachment_input/test_attachment_input.py . [  5%]
                                                                         [  5%]
pkg-py/tests/playwright/chat/auto_cancel_core/test_chat_auto_cancel_core.py . [  6%]
                                                                         [  6%]
pkg-py/tests/playwright/chat/auto_core/test_chat_auto_core.py ....       [ 10%]
pkg-py/tests/playwright/chat/auto_express/test_chat_auto_express.py .... [ 14%]
                                                                         [ 14%]
pkg-py/tests/playwright/chat/basic/test_chat_basic.py .                  [ 15%]
pkg-py/tests/playwright/chat/bookmark/test_chat_bookmark_restore.py .    [ 16%]
pkg-py/tests/playwright/chat/bookmark_attachment/test_bookmark_attachment.py . [ 17%]
                                                                         [ 17%]
pkg-py/tests/playwright/chat/bookmark_html_deps/test_bookmark_html_deps.py . [ 18%]
                                                                         [ 18%]
pkg-py/tests/playwright/chat/bookmark_html_deps_stream/test_bookmark_html_deps_stream.py . [ 19%]
                                                                         [ 19%]
pkg-py/tests/playwright/chat/bookmark_mixed_thinking_stream/test_bookmark_mixed_thinking_stream.py . [ 20%]
                                                                         [ 20%]
pkg-py/tests/playwright/chat/bookmark_no_store/test_bookmark_no_store.py . [ 21%]
                                                                         [ 21%]
pkg-py/tests/playwright/chat/bookmark_slash_commands/test_bookmark_slash_commands.py . [ 22%]
                                                                         [ 22%]
pkg-py/tests/playwright/chat/client_state/test_messages_source.py .      [ 23%]
pkg-py/tests/playwright/chat/client_state/test_resubmit.py .             [ 24%]
pkg-py/tests/playwright/chat/dynamic_ui/test_chat_dynamic_ui.py .        [ 25%]
pkg-py/tests/playwright/chat/errors/test_chat_errors.py .                [ 25%]
pkg-py/tests/playwright/chat/greeting/test_chat_greeting.py .......      [ 32%]
pkg-py/tests/playwright/chat/history/test_history.py .                   [ 33%]
pkg-py/tests/playwright/chat/history_actions/test_history_actions.py .   [ 34%]
pkg-py/tests/playwright/chat/history_auto_memory_reload/test_history_auto_memory_reload.py . [ 35%]
                                                                         [ 35%]
pkg-py/tests/playwright/chat/history_bookmark/test_history_bookmark.py . [ 36%]
..                                                                       [ 38%]
pkg-py/tests/playwright/chat/history_bookmark_with_state/test_history_bookmark_with_state.py . [ 39%]
.                                                                        [ 40%]
pkg-py/tests/playwright/chat/history_cross_session_deps/test_history_cross_session_deps.py . [ 41%]
                                                                         [ 41%]
pkg-py/tests/playwright/chat/history_current/test_history_current.py ... [ 44%]
                                                                         [ 44%]
pkg-py/tests/playwright/chat/history_edit/test_history_edit.py ......... [ 52%]
                                                                         [ 52%]
pkg-py/tests/playwright/chat/history_idempotent_save/test_history_idempotent_save.py . [ 53%]
                                                                         [ 53%]
pkg-py/tests/playwright/chat/history_out_of_band/test_history_out_of_band.py . [ 54%]
                                                                         [ 54%]
pkg-py/tests/playwright/chat/history_restore_on_reload/test_history_restore_on_reload.py . [ 55%]
                                                                         [ 55%]
pkg-py/tests/playwright/chat/history_ui_offset_after_restore/test_history_ui_offset_after_restore.py . [ 56%]
                                                                         [ 56%]
pkg-py/tests/playwright/chat/icon/test_chat_icon.py .                    [ 57%]
pkg-py/tests/playwright/chat/image_input/test_image_input.py .           [ 58%]
pkg-py/tests/playwright/chat/input-suggestion/test_chat_input_suggestion.py . [ 59%]
                                                                         [ 59%]
pkg-py/tests/playwright/chat/message_stream_context/test_chat_message_stream_context.py . [ 60%]
                                                                         [ 60%]
pkg-py/tests/playwright/chat/module/test_chat_module.py .                [ 61%]
pkg-py/tests/playwright/chat/move/test_chat_move.py .                    [ 62%]
pkg-py/tests/playwright/chat/scroll_on_send/test_scroll_on_send.py .     [ 63%]
pkg-py/tests/playwright/chat/shiny_input/test_chat_shiny_input.py .      [ 64%]
pkg-py/tests/playwright/chat/shiny_output/test_chat_shiny_output.py .    [ 65%]
pkg-py/tests/playwright/chat/slash_commands/test_chat_slash_commands.py . [ 66%]
........                                                                 [ 74%]
pkg-py/tests/playwright/chat/stream/test_chat_stream.py .                [ 75%]
pkg-py/tests/playwright/chat/stream-result/test_chat_stream_result.py .  [ 75%]
pkg-py/tests/playwright/chat/transform_assistant/test_chat_transform_assistant.py . [ 76%]
                                                                         [ 76%]
pkg-py/tests/playwright/chat/transform_assistant_stream/test_chat_transform_assistant_stream.py . [ 77%]
                                                                         [ 77%]
pkg-py/tests/playwright/chat/update_user_input/test_chat_update_user_input.py . [ 78%]
                                                                         [ 78%]
pkg-py/tests/playwright/chat/update_user_input_attachments/test_update_user_input_attachments.py . [ 79%]
....                                                                     [ 83%]
pkg-py/tests/playwright/chat/upload_toggle/test_upload_toggle.py .       [ 84%]
pkg-py/tests/playwright/chat/web_asides/test_web_asides.py ......        [ 90%]
pkg-py/tests/playwright/tools/custom_output/test_custom_output.py ..     [ 92%]
pkg-py/tests/playwright/tools/fullscreen/test_fullscreen_focus.py ...... [ 98%]
.                                                                        [ 99%]
pkg-py/tests/playwright/tools/html_title/test_html_title.py .            [100%]

======================= 104 passed in 136.49s (0:02:16) ========================
uv run pytest --ignore=pkg-py/tests/playwright/
============================= test session starts ==============================
platform darwin -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/cpsievert/github/shinychat/.worktrees/fix-bookmark-test-sync
configfile: pyproject.toml
testpaths: pkg-py/tests
plugins: playwright-0.9.0, langsmith-0.10.18, anyio-4.14.2, shiny-1.7.0, base-url-2.1.0
collected 397 items

pkg-py/tests/pytest/test_attachments.py .......................          [  5%]
pkg-py/tests/pytest/test_bookmark_serialization.py .                     [  6%]
pkg-py/tests/pytest/test_chat.py ....................................... [ 15%]
...........                                                              [ 18%]
pkg-py/tests/pytest/test_chat_auto.py ..............................     [ 26%]
pkg-py/tests/pytest/test_chat_segments.py ....                           [ 27%]
pkg-py/tests/pytest/test_greeting.py .........................           [ 33%]
pkg-py/tests/pytest/test_html_islands.py ...........                     [ 36%]
pkg-py/tests/pytest/test_import.py .                                     [ 36%]
pkg-py/tests/pytest/test_input_handler.py .....                          [ 37%]
pkg-py/tests/pytest/test_tool_condensed_view.py ........................ [ 43%]
...............                                                          [ 47%]
pkg-py/tests/pytest/test_tool_wire_protocol.py .                         [ 47%]
pkg-py/tests/test_chat_history.py .............                          [ 51%]
pkg-py/tests/test_history_bookmark_helpers.py ......                     [ 52%]
pkg-py/tests/test_history_client.py ...........                          [ 55%]
pkg-py/tests/test_history_controller.py ................................ [ 63%]
...........................                                              [ 70%]
pkg-py/tests/test_history_dir.py .....                                   [ 71%]
pkg-py/tests/test_history_matrix.py .............                        [ 74%]
pkg-py/tests/test_history_store.py ..................................... [ 84%]
...................                                                      [ 88%]
pkg-py/tests/test_history_title.py .........                             [ 91%]
pkg-py/tests/test_history_types.py ..............................        [ 98%]
pkg-py/tests/test_messages_input_handler.py .....                        [100%]

=============================== warnings summary ===============================
pkg-py/tests/test_history_controller.py::test_evict_if_needed_removes_oldest_preserves_active
pkg-py/tests/test_history_controller.py::test_evict_if_needed_calls_list_once_and_never_total_size
  /Users/cpsievert/github/shinychat/.worktrees/fix-bookmark-test-sync/pkg-py/src/shinychat/_history.py:376: UserWarning: Chat history for this partition remains over the 1-byte limit after evicting all evictable conversations — the active conversation alone exceeds the limit.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 397 passed, 2 warnings in 2.36s ======================== on Python 3.13
- Reran the original failed Python 3.13 GitHub Actions job successfully