### PR TITLE
Prepare shinychat for RenderedHTML value objects

### DIFF
--- a/pkg-py/src/shinychat/_chat_normalize_chatlas.py
+++ b/pkg-py/src/shinychat/_chat_normalize_chatlas.py
@@ -210,10 +210,10 @@ class ToolResultComponent(ToolCardComponent):
         if self.value_type == "html":
             value_ui = TagList(self.value).render()
         else:
-            value_ui: "RenderedHTML" = {
-                "html": str(self.value),
-                "dependencies": [],
-            }
+            value_ui = RenderedHTML(
+                html=str(self.value),
+                dependencies=[],
+            )
 
         footer_ui = TagList(self.footer).render()
 

--- a/pkg-py/src/shinychat/_markdown_stream.py
+++ b/pkg-py/src/shinychat/_markdown_stream.py
@@ -362,7 +362,7 @@ def output_markdown_stream(
     # `content` is most likely a string, so avoid overhead in that case
     # (it's also important that we *don't escape HTML* here).
     if isinstance(content, str):
-        ui: RenderedHTML = {"html": content, "dependencies": []}
+        ui = RenderedHTML(html=content, dependencies=[])
     else:
         ui = TagList(*split_html_islands(content)).render()
 


### PR DESCRIPTION
## Why this matters

posit-dev/py-htmltools#123 changes `RenderedHTML` from a structural `TypedDict` into the dict-compatible value object returned by `render()`. Shinychat currently creates two plain dictionaries under that annotation, which makes downstream Pyright fail against the proposed htmltools release.

Using the public constructor keeps shinychat compatible with both the current htmltools `TypedDict` constructor and the proposed value object, so this can land independently before htmltools is released. Runtime output is unchanged.

## Verification

Verified from a fresh `uv sync --all-extras` environment after installing the wheel built from posit-dev/py-htmltools#123:

- `uv run --no-sync pyright`
- `uv run --no-sync pytest -q --ignore=pkg-py/tests/playwright` (424 passed)
- `uv run --no-sync ruff check pkg-py --config pyproject.toml`
- Changed-file Ruff format check
- Source distribution and wheel build
