### PR TITLE
fix(py): normalize reported HTML dependencies

### DIFF
--- a/pkg-py/src/shinychat/_input_handler.py
+++ b/pkg-py/src/shinychat/_input_handler.py
@@ -67,13 +67,15 @@ def messages_input_value(value: Any) -> list[StoredMessage]:
         # malformed message is a client/protocol bug we surface loudly rather
         # than silently drop (which would be invisible data loss on save). The
         # R handler (chat_history_types.R) takes the same posture.
-        segments = [
-            StoredSegment(content=s["content"], content_type=s["content_type"])
-            for s in m.get("segments", [])
-        ]
         html_deps = m.get("htmlDeps")
-        if html_deps and segments:
-            segments[0].html_deps = html_deps
+        segments = [
+            StoredSegment(
+                content=s["content"],
+                content_type=s["content_type"],
+                html_deps=html_deps if i == 0 else None,
+            )
+            for i, s in enumerate(m.get("segments", []))
+        ]
         attachments = [
             Attachment.model_validate(a) for a in (m.get("attachments") or [])
         ]

--- a/pkg-py/src/shinychat/_input_handler.py
+++ b/pkg-py/src/shinychat/_input_handler.py
@@ -67,6 +67,8 @@ def messages_input_value(value: Any) -> list[StoredMessage]:
         # malformed message is a client/protocol bug we surface loudly rather
         # than silently drop (which would be invisible data loss on save). The
         # R handler (chat_history_types.R) takes the same posture.
+        # The browser reports dependencies at message scope. Store them once
+        # because StoredMessage.html_deps aggregates dependencies across segments.
         html_deps = m.get("htmlDeps")
         segments = [
             StoredSegment(

--- a/pkg-py/tests/test_messages_input_handler.py
+++ b/pkg-py/tests/test_messages_input_handler.py
@@ -1,26 +1,33 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 from shinychat._chat_types import StoredMessage
 from shinychat._input_handler import messages_input_value
 
 
 def test_messages_handler_deserializes_snapshot():
-    payload = [
+    payload = (
         {
             "role": "user",
-            "segments": [{"content": "hi", "content_type": "markdown"}],
+            "segments": ({"content": "hi", "content_type": "markdown"},),
         },
         {
             "role": "assistant",
-            "segments": [{"content": "yo", "content_type": "markdown"}],
-            "htmlDeps": [{"name": "w", "version": "1.0.0"}],
+            "segments": ({"content": "yo", "content_type": "markdown"},),
+            "htmlDeps": ({"name": "w", "version": "1.0.0"},),
         },
-    ]
+    )
     out = messages_input_value(payload)
     assert all(isinstance(m, StoredMessage) for m in out)
     assert out[0].role == "user"
     assert out[1].segments[0].html_deps == [{"name": "w", "version": "1.0.0"}]
+    assert isinstance(out[1].segments[0].html_deps, list)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out[1].model_dump_json()
 
 
 def test_messages_handler_raises_on_message_missing_content_type():


### PR DESCRIPTION
## Why this matters

Rich chat messages with HTML dependencies no longer emit Pydantic serializer warnings when saved. Shiny converts incoming JSON arrays to tuples, but shinychat previously assigned the nested `htmlDeps` tuple after Pydantic model construction, bypassing validation for a field declared as a list.

## What changes

- Pass reported HTML dependencies through `StoredSegment` construction so Pydantic validates and normalizes them.
- Exercise the tuple-shaped payload produced by Shiny and treat serialization warnings as test failures.

## Verification

- `uv run pytest pkg-py/tests/test_messages_input_handler.py::test_messages_handler_deserializes_snapshot -q` reproduces Shiny’s tuple-shaped `htmlDeps` payload and verifies warning-free serialization.
- `uv run pytest pkg-py/tests --ignore=pkg-py/tests/playwright -q` (`448 passed`)
- `uv run pytest pkg-py/tests/playwright -q` (`113 passed`)
- Ruff
- Pyright