### PR TITLE
Point the RStudio project at `pkg-r/`

### DIFF
--- a/shinychat.Rproj
+++ b/shinychat.Rproj
@@ -17,5 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackagePath: pkg-r
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
## Summary

`shinychat.Rproj` declares `BuildType: Package` and `PackageUseDevtools: Yes`,
but no `PackagePath`. So RStudio and Positron look for the package at the
repository root, where there is no `DESCRIPTION` — the R package lives in
`pkg-r/`. `PackagePath` is the field RStudio provides for exactly this layout:

```diff
 BuildType: Package
 PackageUseDevtools: Yes
+PackagePath: pkg-r
```

The same convention is used by other repositories that keep their package in a
subdirectory — `PackagePath: rkeops` in
[getkeops/keops](https://github.com/getkeops/keops), `PackagePath: release/missRanger`
in [mayer79/missRanger](https://github.com/mayer79/missRanger).

## Effect

- RStudio's / Positron's Build pane (Install, Test, Check, Document) acts on
  `pkg-r/` instead of failing at the repository root.
- Nothing else changes: CI, `.github/workflows/`, the Makefile and the Python and
  JS builds don't read `.Rproj`.

It also feeds a proposed rprojroot change, r-lib/rprojroot#240, which teaches
`find_package_root_file()` to honor `PackagePath` (and, failing that, the
`pkg-r`/`r`/`R` convention that pkgdepends already uses when installing from
GitHub, r-lib/pkgdepends#466). With that branch installed, `devtools::load_all()`
resolves this repository from the root:

```
$ Rscript -e 'devtools::load_all()'       # run at the repository root
ℹ Loading shinychat
pkgload::pkg_path(): .../shinychat/pkg-r
```

That part is not needed for this PR to be useful — the Build pane fix stands on
its own with released tooling.

Draft pending a look from someone who uses the RStudio Build pane here, in case
`pkg-r` isn't the directory you'd want targeted.
