### PR TITLE
fix: register bookmark-mode onBookmarked() on root session

### DIFF
--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -862,7 +862,10 @@ chat_enable_history <- function(
 
     controller$on_response_saved <- function(record) {
       captured_id <- record$id
-      cancel_bm <- session$onBookmarked(function(url) {
+      # Register on the root session: module session proxies forbid
+      # onBookmarked() ("onBookmarked() can't be used in a module."), and
+      # rootScope() returns the session itself when not in a module.
+      cancel_bm <- session$rootScope()$onBookmarked(function(url) {
         new_state_id <- extract_state_id(url)
         if (is.null(new_state_id)) {
           return()

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -662,6 +662,56 @@ test_that("bookmark mode pre-switch emits reload navigation", {
   expect_true(nav[[1]]$message$action$reload)
 })
 
+test_that("bookmark mode on_response_saved works from a module session", {
+  # Shiny's module session proxy forbids onBookmarked():
+  #   stop("onBookmarked() can't be used in a module.")
+  # (shiny/R/shiny.R, in makeScope()). MockShinySession$makeScope() doesn't
+  # emulate that restriction, so build a faithful proxy by hand.
+  root <- shiny::MockShinySession$new()
+
+  registered_on <- NULL
+  # MockShinySession$onBookmarked() is a noop returning NULL; give it a
+  # realistic cancel-function return value and record which session the
+  # callback was registered on.
+  root$onBookmarked <- function(fun) {
+    registered_on <<- "root"
+    function() invisible(NULL)
+  }
+
+  mod_session <- shiny:::createSessionProxy(
+    root,
+    ns = shiny::NS("mod"),
+    onBookmarked = function(fun) {
+      stop("onBookmarked() can't be used in a module.")
+    }
+  )
+
+  client <- mock_chat_client()
+  store <- InMemoryConversationStore$new()
+
+  old_bookmark_store <- shiny::getShinyOption("bookmarkStore", NULL)
+  shiny::shinyOptions(bookmarkStore = "server")
+  withr::defer(shiny::shinyOptions(bookmarkStore = old_bookmark_store))
+
+  chat_enable_history(
+    "chat",
+    client,
+    options = history_options(
+      store = store,
+      scope = "test-user",
+      restore_mode = "bookmark",
+      title = NULL
+    ),
+    session = mod_session
+  )
+
+  ctrl <- get_session_chat_bookmark_info(mod_session, "chat.history-controller")
+  record <- new_conversation_record("conv1")
+
+  expect_no_error(ctrl$on_response_saved(record))
+  expect_identical(registered_on, "root")
+})
+
 test_that("delete_bookmark_state removes Shiny appDir server bookmark state", {
   old_app_dir <- shiny::getShinyOption("appDir", NULL)
   old_bookmark_save_dir <- shiny::getShinyOption("bookmarkSaveDir", NULL)


### PR DESCRIPTION
Closes #346

## Summary

Bookmark-mode history (`history_options(restore_mode = "bookmark")`) failed to save whenever the chat was hosted inside a Shiny module, because the save hook in `R/chat_history.R` registered its `onBookmarked()` callback on the module-scoped session — and Shiny's module session proxy blocks exactly that method (`onBookmarked() can't be used in a module.`). The save aborted, so the conversation was never persisted and history did not restore after reload.

The fix registers the callback on `session$rootScope()` instead, mirroring the existing guard in `R/chat_restore.R` and the Python package's `root_session.bookmark.on_bookmarked` usage. `rootScope()` returns the session itself outside modules, so top-level apps are unaffected.

A regression test emulates the module proxy restriction (via `shiny:::createSessionProxy` with the same `stop()` override Shiny uses) and drives `on_response_saved` in bookmark mode, asserting both that no error is thrown and that registration lands on the root session.

## Verification

Run the reprex from #346 (a module-hosted chat with `restore_mode = "bookmark"`): send a message, let the response finish, and confirm the "Could not save conversation" toast no longer appears and history restores after reload. Note the module restriction on `onBookmarked()` only exists in dev Shiny, so the reprex requires that to reproduce the original error; the included test emulates it on any Shiny version. `devtools::test()` passes (the 8 failures in shinytest2/greeting tests pre-exist on main).
