### PR TITLE
fix(py): flush queued appends after message stream context

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -1133,6 +1133,7 @@ class Chat:
                     chunk="end",
                     stream_id=stream_id,
                 )
+                await self._flush_pending_messages()
 
     async def _append_message_chunk(
         self,

--- a/pkg-py/tests/pytest/test_chat.py
+++ b/pkg-py/tests/pytest/test_chat.py
@@ -956,6 +956,34 @@ def test_stream_thinking_creates_thinking_segment():
         assert by_content["answer"] == "markdown"
 
 
+def test_message_stream_context_flushes_queued_appends():
+    with session_context(test_session):
+        chat = Chat(id="chat")
+        sent: list[dict[str, Any]] = []
+
+        async def _capture(action: Any, deps: Any = None) -> None:
+            sent.append(action)
+
+        chat._send_action = _capture  # type: ignore[method-assign]
+
+        async def _exercise() -> None:
+            async with chat.message_stream_context() as stream:
+                await stream.append("streamed")
+                await chat.append_message("queued")
+
+        run_async(_exercise)
+
+        assert sent[-1] == {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "segments": [
+                    {"content": "queued", "content_type": "markdown"}
+                ],
+            },
+        }
+
+
 def test_thinking_stream_stores_segment_not_tags():
     with session_context(test_session):
         chat = Chat(id="chat")


### PR DESCRIPTION
## Summary
When `append_message()` is called while a bare `message_stream_context()` is active, Chat queues the append to preserve message ordering. Previously, a bare context ended its stream but never drained that queue, so the queued message was never sent to the browser.

Drain pending appends after the root stream context sends its end chunk. Nested contexts continue to share their parent stream and do not flush independently.

Add regression coverage that opens a bare streaming context, queues an append, exits the context, and verifies the queued message is delivered.

## Verification

```bash
uv run pytest pkg-py/tests/pytest/test_chat.py -q -k 'message_stream_context_flushes_queued_appends or stream'
uv run ruff check pkg-py/src/shinychat/_chat.py pkg-py/tests/pytest/test_chat.py --config pyproject.toml
uv run pyright pkg-py/src/shinychat/_chat.py
```