### PR TITLE
fix(history-store): atomic writes and tolerant reads

### DIFF
--- a/.github/workflows/verify-js-built.yaml
+++ b/.github/workflows/verify-js-built.yaml
@@ -46,8 +46,8 @@ jobs:
       - name: 🏭 Build
         run: make js-build
 
-      - name: 🔄 Sync history matrix fixture
-        run: make history-matrix-sync
+      - name: 🔄 Sync test fixtures into R package
+        run: make r-sync-fixtures
 
       - name: 🧐 Check for uncommitted changes
         run: |

--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,10 @@ r-coverage:  ## [r] Generate R coverage report
 	@echo "📔 Generating R coverage report"
 	cd $(PATH_PKG_R) && Rscript -e "covr::report(covr::package_coverage(), file = 'coverage-report.html', browse = FALSE)"
 
-.PHONY: history-matrix-sync
-history-matrix-sync: ## Sync shared history test matrices into pkg-r
+.PHONY: r-sync-fixtures
+r-sync-fixtures: ## [r] Sync shared history test fixtures into pkg-r
 	@echo ""
-	@echo "🔄 Syncing history test matrices into pkg-r"
+	@echo "🔄 Syncing shared history test fixtures into pkg-r"
 	mkdir -p $(PATH_PKG_R)/tests/testthat/fixtures
 	cp tests/shared/history-behavior-matrix.json \
 		$(PATH_PKG_R)/tests/testthat/fixtures/history-behavior-matrix.json
@@ -120,7 +120,7 @@ history-matrix-sync: ## Sync shared history test matrices into pkg-r
 		$(PATH_PKG_R)/tests/testthat/fixtures/history-store-fixture-matrix.json
 
 .PHONY: r-update-dist
-r-update-dist: history-matrix-sync ## [r] Update shinychat web assets
+r-update-dist: r-sync-fixtures ## [r] Update shinychat web assets
 	@echo ""
 	@echo "🔄 Updating shinychat web assets"
 	if [ -d $(PATH_PKG_R)/inst/lib/shiny ]; then \

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,14 @@ r-coverage:  ## [r] Generate R coverage report
 	cd $(PATH_PKG_R) && Rscript -e "covr::report(covr::package_coverage(), file = 'coverage-report.html', browse = FALSE)"
 
 .PHONY: history-matrix-sync
-history-matrix-sync: ## Sync the shared history-behavior test matrix into pkg-r
+history-matrix-sync: ## Sync shared history test matrices into pkg-r
 	@echo ""
-	@echo "🔄 Syncing history behavior matrix into pkg-r"
+	@echo "🔄 Syncing history test matrices into pkg-r"
 	mkdir -p $(PATH_PKG_R)/tests/testthat/fixtures
 	cp tests/shared/history-behavior-matrix.json \
 		$(PATH_PKG_R)/tests/testthat/fixtures/history-behavior-matrix.json
+	cp tests/shared/history-store-fixture-matrix.json \
+		$(PATH_PKG_R)/tests/testthat/fixtures/history-store-fixture-matrix.json
 
 .PHONY: r-update-dist
 r-update-dist: history-matrix-sync ## [r] Update shinychat web assets

--- a/pkg-py/src/shinychat/_history_store.py
+++ b/pkg-py/src/shinychat/_history_store.py
@@ -129,6 +129,11 @@ class FileConversationStore(ConversationStore):
     atomically on every save). ``turns.jsonl`` and ``ui.jsonl`` are
     append-only — new turns and UI entries are appended, never rewritten.
 
+    Temporary records and journal rollback protect against ordinary I/O
+    failures, but this store does not fsync files or directories. It also
+    does not coordinate concurrent access across processes; callers must
+    serialize reads and writes for each conversation.
+
     On ``get()``, the three files are read and merged into a full
     ``ConversationRecord`` with inline turns and UI on each node. Callers
     never see the split.

--- a/pkg-py/src/shinychat/_history_store.py
+++ b/pkg-py/src/shinychat/_history_store.py
@@ -88,13 +88,35 @@ class ConversationStore(ABC):
 @dataclasses.dataclass
 class _WriteState:
     turn_seq_map: dict[str, list[int]] = dataclasses.field(default_factory=dict)
-    # node_id -> count of UI messages last persisted for that node. A node's
-    # `ui` is append-only, so a change in length is a sufficient dirty-check;
-    # on change we re-append the node's full current UI. get() reads
-    # ui.jsonl last-write-wins, so the newest (longest) line for a node id
-    # is always what's returned.
-    ui_node_len: dict[str, int] = dataclasses.field(default_factory=dict)
+    # node_id -> digest of the UI messages last persisted for that node.
+    # ui.jsonl is last-write-wins, so any content change must re-append the
+    # complete current UI, even if its message count did not change.
+    ui_node_digest: dict[str, str] = dataclasses.field(default_factory=dict)
     next_turn_seq: int = 0
+
+
+def _json_digest(value: object) -> str:
+    data = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def _append_jsonl(path: Path, lines: list[str]) -> None:
+    with open(path, "a", encoding="utf-8") as f:
+        if lines:
+            f.write("\n".join(lines) + "\n")
+
+
+def _rollback_jsonl(path: Path, *, existed: bool, size: int) -> None:
+    if existed:
+        with open(path, "r+b") as f:
+            f.truncate(size)
+    else:
+        path.unlink(missing_ok=True)
 
 
 class FileConversationStore(ConversationStore):
@@ -147,14 +169,33 @@ class FileConversationStore(ConversationStore):
                     ws.turn_seq_map[nid] = turn_ids
         ui_file = conv_dir / "ui.jsonl"
         if ui_file.is_file():
-            for line in (
-                ui_file.read_text(encoding="utf-8").strip().splitlines()
+            for line_number, line in enumerate(
+                ui_file.read_text(encoding="utf-8").splitlines(), start=1
             ):
+                if not line:
+                    continue
                 try:
                     entry = json.loads(line)
-                    ws.ui_node_len[entry["node_id"]] = len(entry["data"])
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    continue
+                    if (
+                        not isinstance(entry, dict)
+                        or not isinstance(entry.get("node_id"), str)
+                        or not isinstance(entry.get("data"), list)
+                    ):
+                        raise ValueError("expected node_id and data")
+                    ws.ui_node_digest[entry["node_id"]] = _json_digest(
+                        entry["data"]
+                    )
+                except (
+                    json.JSONDecodeError,
+                    KeyError,
+                    TypeError,
+                    ValueError,
+                ):
+                    logger.warning(
+                        "Skipping malformed JSONL line %s:%d",
+                        ui_file,
+                        line_number,
+                    )
         self._write_state[key] = ws
         return ws
 
@@ -225,26 +266,60 @@ class FileConversationStore(ConversationStore):
         turns_map: dict[int, dict[str, Any]] = {}
         turns_file = conv_dir / "turns.jsonl"
         if turns_file.is_file():
-            for line in (
-                turns_file.read_text(encoding="utf-8").strip().splitlines()
+            for line_number, line in enumerate(
+                turns_file.read_text(encoding="utf-8").splitlines(), start=1
             ):
+                if not line:
+                    continue
                 try:
                     entry = json.loads(line)
+                    if (
+                        not isinstance(entry, dict)
+                        or type(entry.get("seq")) is not int
+                        or not isinstance(entry.get("data"), dict)
+                    ):
+                        raise ValueError("expected seq and data")
                     turns_map[entry["seq"]] = entry["data"]
-                except (json.JSONDecodeError, KeyError):
-                    continue
+                except (
+                    json.JSONDecodeError,
+                    KeyError,
+                    TypeError,
+                    ValueError,
+                ):
+                    logger.warning(
+                        "Skipping malformed JSONL line %s:%d",
+                        turns_file,
+                        line_number,
+                    )
 
         ui_map: dict[str, list[dict[str, Any]]] = {}
         ui_file = conv_dir / "ui.jsonl"
         if ui_file.is_file():
-            for line in (
-                ui_file.read_text(encoding="utf-8").strip().splitlines()
+            for line_number, line in enumerate(
+                ui_file.read_text(encoding="utf-8").splitlines(), start=1
             ):
+                if not line:
+                    continue
                 try:
                     entry = json.loads(line)
+                    if (
+                        not isinstance(entry, dict)
+                        or not isinstance(entry.get("node_id"), str)
+                        or not isinstance(entry.get("data"), list)
+                    ):
+                        raise ValueError("expected node_id and data")
                     ui_map[entry["node_id"]] = entry["data"]
-                except (json.JSONDecodeError, KeyError):
-                    continue
+                except (
+                    json.JSONDecodeError,
+                    KeyError,
+                    TypeError,
+                    ValueError,
+                ):
+                    logger.warning(
+                        "Skipping malformed JSONL line %s:%d",
+                        ui_file,
+                        line_number,
+                    )
 
         nodes: dict[str, ConversationNode] = {}
         for nid, node_data in raw.get("nodes", {}).items():
@@ -291,18 +366,27 @@ class FileConversationStore(ConversationStore):
 
         conv_dir.mkdir(parents=True, exist_ok=True)
 
+        ws_key = self._ws_key(partition, record.id)
+        had_write_state = ws_key in self._write_state
         ws = self._get_or_init_write_state(partition, record.id, conv_dir)
+        staged_ws = dataclasses.replace(
+            ws,
+            turn_seq_map={
+                nid: list(turn_ids) for nid, turn_ids in ws.turn_seq_map.items()
+            },
+            ui_node_digest=dict(ws.ui_node_digest),
+        )
 
         new_turns_lines: list[str] = []
         new_ui_lines: list[str] = []
         record_nodes: dict[str, dict[str, Any]] = {}
 
         for nid, node in record.nodes.items():
-            if nid not in ws.turn_seq_map:
+            if nid not in staged_ws.turn_seq_map:
                 turn_ids: list[int] = []
                 for turn_data in node.turns:
-                    seq = ws.next_turn_seq
-                    ws.next_turn_seq += 1
+                    seq = staged_ws.next_turn_seq
+                    staged_ws.next_turn_seq += 1
                     turn_ids.append(seq)
                     new_turns_lines.append(
                         json.dumps(
@@ -310,35 +394,23 @@ class FileConversationStore(ConversationStore):
                             ensure_ascii=False,
                         )
                     )
-                ws.turn_seq_map[nid] = turn_ids
-            if node.ui is not None and len(node.ui) != ws.ui_node_len.get(nid):
-                new_ui_lines.append(
-                    json.dumps(
-                        {"node_id": nid, "data": node.ui},
-                        ensure_ascii=False,
+                staged_ws.turn_seq_map[nid] = turn_ids
+            if node.ui is not None:
+                ui_digest = _json_digest(node.ui)
+                if ui_digest != staged_ws.ui_node_digest.get(nid):
+                    new_ui_lines.append(
+                        json.dumps(
+                            {"node_id": nid, "data": node.ui},
+                            ensure_ascii=False,
+                        )
                     )
-                )
-                ws.ui_node_len[nid] = len(node.ui)
+                    staged_ws.ui_node_digest[nid] = ui_digest
             record_nodes[nid] = {
                 "parent": node.parent,
                 "children": node.children,
-                "turn_ids": ws.turn_seq_map.get(nid, []),
+                "turn_ids": staged_ws.turn_seq_map.get(nid, []),
                 "selected_child": node.selected_child,
             }
-
-        turns_file = conv_dir / "turns.jsonl"
-        if new_turns_lines:
-            with open(turns_file, "a", encoding="utf-8") as f:
-                f.write("\n".join(new_turns_lines) + "\n")
-        elif not turns_file.exists():
-            turns_file.touch()
-
-        ui_file = conv_dir / "ui.jsonl"
-        if new_ui_lines:
-            with open(ui_file, "a", encoding="utf-8") as f:
-                f.write("\n".join(new_ui_lines) + "\n")
-        elif not ui_file.exists():
-            ui_file.touch()
 
         record_data = {
             "schema_version": record.schema_version,
@@ -355,12 +427,36 @@ class FileConversationStore(ConversationStore):
             "values": record.values,
             "bookmark_state_id": record.bookmark_state_id,
         }
+        record_json = json.dumps(record_data, ensure_ascii=False)
+
+        turns_file = conv_dir / "turns.jsonl"
+        ui_file = conv_dir / "ui.jsonl"
+        jsonl_snapshots = [
+            (
+                path,
+                path.exists(),
+                path.stat().st_size if path.exists() else 0,
+            )
+            for path in (turns_file, ui_file)
+        ]
         tmp = conv_dir / ".record.json.tmp"
-        tmp.write_text(
-            json.dumps(record_data, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        os.replace(tmp, conv_dir / "record.json")
+        try:
+            # Serialize and write the replacement record before appending
+            # journal entries. A later append or rename failure rolls those
+            # entries back to these snapshots.
+            tmp.write_text(record_json, encoding="utf-8")
+            _append_jsonl(turns_file, new_turns_lines)
+            _append_jsonl(ui_file, new_ui_lines)
+            os.replace(tmp, record_file)
+        except Exception:
+            for path, existed, size in reversed(jsonl_snapshots):
+                _rollback_jsonl(path, existed=existed, size=size)
+            tmp.unlink(missing_ok=True)
+            if not had_write_state:
+                self._write_state.pop(ws_key, None)
+            raise
+
+        self._write_state[ws_key] = staged_ws
 
         if partition in self._meta_cache:
             size_bytes = sum(

--- a/pkg-py/tests/test_history_matrix.py
+++ b/pkg-py/tests/test_history_matrix.py
@@ -3,7 +3,7 @@
 # Scenarios are defined once in tests/shared/history-behavior-matrix.json and
 # consumed by both this file and pkg-r/tests/testthat/test-chat_history_matrix.R
 # (via the vendored copy at pkg-r/tests/testthat/fixtures/, kept in sync by
-# `make history-matrix-sync`; CI fails the build if that copy drifts — see
+# `make r-sync-fixtures`; CI fails the build if that copy drifts — see
 # .github/workflows/verify-js-built.yaml).
 #
 # Only scenarios whose operation has a matching signature in both languages

--- a/pkg-py/tests/test_history_store.py
+++ b/pkg-py/tests/test_history_store.py
@@ -49,12 +49,7 @@ STORE_MATRIX = {
 
 
 def _conv_dir(tmp_path: Path, rec: ConversationRecord) -> Path:
-    return (
-        tmp_path
-        / sanitize_scope("chat")
-        / sanitize_scope("alice")
-        / rec.id
-    )
+    return tmp_path / sanitize_scope("chat") / sanitize_scope("alice") / rec.id
 
 
 def _file_snapshot(path: Path) -> dict[str, bytes]:
@@ -420,7 +415,7 @@ async def test_store_fixture_matrix_grown_content_same_count_is_repersisted(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("failure_step", ["serialize", "append", "rename"])
-async def test_put_failure_rolls_back_all_journal_changes(
+async def test_put_failure_leaves_files_unchanged(
     store: FileConversationStore,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/pkg-py/tests/test_history_store.py
+++ b/pkg-py/tests/test_history_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import shinychat._history_store as history_store_module
 from htmltools import HTMLDependency, tags
 from shinychat._history_client import as_turns_adapter
 from shinychat._history_store import (
@@ -33,6 +34,35 @@ def store(tmp_path: Path) -> FileConversationStore:
 
 def part(chat_id: str = "chat", scope: str = "alice") -> ConversationPartition:
     return ConversationPartition(chat_id=chat_id, scope=scope)
+
+
+STORE_MATRIX_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "shared"
+    / "history-store-fixture-matrix.json"
+)
+STORE_MATRIX = {
+    case["name"]: case
+    for case in json.loads(STORE_MATRIX_PATH.read_text(encoding="utf-8"))
+}
+
+
+def _conv_dir(tmp_path: Path, rec: ConversationRecord) -> Path:
+    return (
+        tmp_path
+        / sanitize_scope("chat")
+        / sanitize_scope("alice")
+        / rec.id
+    )
+
+
+def _file_snapshot(path: Path) -> dict[str, bytes]:
+    return {
+        file.name: file.read_bytes()
+        for file in path.iterdir()
+        if file.is_file()
+    }
 
 
 @pytest.mark.anyio
@@ -311,6 +341,144 @@ async def test_ui_growth_across_saves_is_repersisted(
     got2 = await store2.get(part(), rec.id)
     assert got2 is not None
     assert got2.nodes[nid].ui == [msg1, msg2]
+
+
+@pytest.mark.anyio
+async def test_store_fixture_matrix_doubles_round_trip(
+    store: FileConversationStore,
+):
+    rec = new_conversation_record(title="doubles")
+    value = STORE_MATRIX["doubles_round_trip"]["value"]
+    rec.values = {"pi": value}
+
+    await store.put(part(), rec)
+
+    got = await store.get(part(), rec.id)
+    assert got is not None
+    assert got.values["pi"] == value
+
+
+@pytest.mark.anyio
+async def test_store_fixture_matrix_malformed_jsonl_line_warns(
+    store: FileConversationStore,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    rec = new_conversation_record(title="malformed")
+    rec.append_linear([{"role": "user", "content": "preserved"}])
+    await store.put(part(), rec)
+    turns_file = _conv_dir(tmp_path, rec) / "turns.jsonl"
+    turns_file.write_text(
+        turns_file.read_text(encoding="utf-8")
+        + STORE_MATRIX["malformed_jsonl_line"]["line"]
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        got = await store.get(part(), rec.id)
+
+    assert got is not None
+    assert got.path_turns() == [{"role": "user", "content": "preserved"}]
+    assert f"{turns_file}:2" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_store_fixture_matrix_grown_content_same_count_is_repersisted(
+    store: FileConversationStore,
+    tmp_path: Path,
+):
+    case = STORE_MATRIX["grown_content_same_count"]
+    rec = new_conversation_record(title="same count")
+    nid = rec.append_linear(
+        [{"role": "assistant", "content": case["initial"]}],
+        ui=[
+            {
+                "role": "assistant",
+                "segments": [
+                    {"content": case["initial"], "content_type": "markdown"}
+                ],
+            }
+        ],
+    )
+    await store.put(part(), rec)
+
+    rec.nodes[nid].ui = [
+        {
+            "role": "assistant",
+            "segments": [
+                {"content": case["updated"], "content_type": "markdown"}
+            ],
+        }
+    ]
+    await store.put(part(), rec)
+
+    got = await FileConversationStore(dir=tmp_path).get(part(), rec.id)
+    assert got is not None
+    assert got.nodes[nid].ui == rec.nodes[nid].ui
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("failure_step", ["serialize", "append", "rename"])
+async def test_put_failure_rolls_back_all_journal_changes(
+    store: FileConversationStore,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_step: str,
+):
+    rec = new_conversation_record(title="rollback")
+    rec.append_linear(
+        [{"role": "user", "content": "first"}],
+        ui=[{"role": "user", "segments": []}],
+    )
+    await store.put(part(), rec)
+    conv_dir = _conv_dir(tmp_path, rec)
+    before = _file_snapshot(conv_dir)
+
+    rec.append_linear(
+        [{"role": "assistant", "content": "second"}],
+        ui=[{"role": "assistant", "segments": []}],
+    )
+
+    with monkeypatch.context() as patch:
+        if failure_step == "serialize":
+            patch.setattr(
+                "shinychat._history_store.json.dumps",
+                lambda *args, **kwargs: (_ for _ in ()).throw(
+                    TypeError("injected serialization failure")
+                ),
+            )
+        elif failure_step == "append":
+            original_append = history_store_module._append_jsonl
+            call_count = 0
+
+            def fail_after_append(path: Path, lines: list[str]) -> None:
+                nonlocal call_count
+                call_count += 1
+                original_append(path, lines)
+                if call_count == 2:
+                    raise OSError("injected append failure")
+
+            patch.setattr(
+                history_store_module, "_append_jsonl", fail_after_append
+            )
+        else:
+            patch.setattr(
+                "shinychat._history_store.os.replace",
+                lambda *args, **kwargs: (_ for _ in ()).throw(
+                    OSError("injected rename failure")
+                ),
+            )
+
+        with pytest.raises((TypeError, OSError)):
+            await store.put(part(), rec)
+
+    assert _file_snapshot(conv_dir) == before
+
+    await FileConversationStore(dir=tmp_path).put(part(), rec)
+    got = await FileConversationStore(dir=tmp_path).get(part(), rec.id)
+    assert got is not None
+    assert len(got.nodes) == 2
 
 
 @pytest.mark.anyio

--- a/pkg-r/R/chat_history_store.R
+++ b/pkg-r/R/chat_history_store.R
@@ -185,6 +185,72 @@ record_json_size <- function(record) {
   as.double(nchar(jsonlite::serializeJSON(record), type = "bytes"))
 }
 
+history_json <- function(value) {
+  as.character(jsonlite::toJSON(
+    value,
+    auto_unbox = TRUE,
+    null = "null",
+    digits = 17
+  ))
+}
+
+history_json_digest <- function(value) {
+  rlang::hash(history_json(value))
+}
+
+history_warn_malformed_jsonl <- function(path, line_number, reason) {
+  rlang::warn(paste0(
+    "Skipping malformed JSONL line ",
+    path,
+    ":",
+    line_number,
+    ": ",
+    reason
+  ))
+}
+
+history_parse_jsonl_line <- function(line, path, line_number) {
+  tryCatch(
+    jsonlite::fromJSON(line, simplifyVector = FALSE),
+    error = function(e) {
+      history_warn_malformed_jsonl(path, line_number, conditionMessage(e))
+      NULL
+    }
+  )
+}
+
+history_append_jsonl <- function(path, lines) {
+  if (length(lines) > 0) {
+    cat(
+      paste0(lines, collapse = "\n"),
+      "\n",
+      file = path,
+      sep = "",
+      append = TRUE
+    )
+  } else if (!file.exists(path)) {
+    file.create(path)
+  }
+  invisible(NULL)
+}
+
+history_rollback_jsonl <- function(path, existed, size) {
+  if (!existed) {
+    unlink(path)
+    return(invisible(NULL))
+  }
+  con <- file(path, open = "r+b")
+  on.exit(close(con), add = TRUE)
+  seek(con, where = size, origin = "start")
+  truncate(con)
+  invisible(NULL)
+}
+
+history_write_temp_record <- function(json, path) {
+  writeLines(json, path)
+  invisible(NULL)
+}
+
 CONV_ID_RE <- "^[A-Za-z0-9_-]{1,80}$"
 
 sanitize_scope <- function(scope) {
@@ -252,7 +318,7 @@ FileConversationStore <- R6::R6Class(
 
       ws <- list(
         turn_seq_map = list(),
-        ui_node_len = list(),
+        ui_node_digest = list(),
         next_turn_seq = 0L
       )
 
@@ -275,17 +341,31 @@ FileConversationStore <- R6::R6Class(
 
       ui_file <- file.path(cdir, "ui.jsonl")
       if (file.exists(ui_file)) {
-        for (line in readLines(ui_file, warn = FALSE)) {
+        for (line_number in seq_along(
+          lines <- readLines(ui_file, warn = FALSE)
+        )) {
+          line <- lines[[line_number]]
           if (!nzchar(line)) {
             next
           }
-          entry <- tryCatch(
-            jsonlite::fromJSON(line, simplifyVector = FALSE),
-            error = function(e) NULL
-          )
-          if (!is.null(entry)) {
-            ws$ui_node_len[[entry$node_id]] <- length(entry$data)
+          entry <- history_parse_jsonl_line(line, ui_file, line_number)
+          if (
+            is.null(entry) ||
+              !is.list(entry) ||
+              !is.character(entry$node_id) ||
+              length(entry$node_id) != 1L ||
+              !is.list(entry$data)
+          ) {
+            if (!is.null(entry)) {
+              history_warn_malformed_jsonl(
+                ui_file,
+                line_number,
+                "expected node_id and data"
+              )
+            }
+            next
           }
+          ws$ui_node_digest[[entry$node_id]] <- history_json_digest(entry$data)
         }
       }
 
@@ -381,20 +461,44 @@ FileConversationStore <- R6::R6Class(
       turns_map <- list()
       turns_file <- file.path(cdir, "turns.jsonl")
       if (file.exists(turns_file)) {
-        for (line in readLines(turns_file, warn = FALSE)) {
+        lines <- readLines(turns_file, warn = FALSE)
+        for (line_number in seq_along(lines)) {
+          line <- lines[[line_number]]
           if (!nzchar(line)) {
             next
           }
-          entry <- tryCatch(
-            {
-              entry <- jsonlite::fromJSON(line, simplifyVector = FALSE)
-              entry$data <- jsonlite::unserializeJSON(entry$data)
-              entry
-            },
-            error = function(e) NULL
+          entry <- history_parse_jsonl_line(line, turns_file, line_number)
+          if (
+            is.null(entry) ||
+              !is.list(entry) ||
+              !is.numeric(entry$seq) ||
+              length(entry$seq) != 1L ||
+              is.na(entry$seq) ||
+              !is.character(entry$data) ||
+              length(entry$data) != 1L
+          ) {
+            if (!is.null(entry)) {
+              history_warn_malformed_jsonl(
+                turns_file,
+                line_number,
+                "expected seq and serialized data"
+              )
+            }
+            next
+          }
+          turn <- tryCatch(
+            jsonlite::unserializeJSON(entry$data),
+            error = function(e) {
+              history_warn_malformed_jsonl(
+                turns_file,
+                line_number,
+                conditionMessage(e)
+              )
+              NULL
+            }
           )
-          if (!is.null(entry)) {
-            turns_map[[as.character(entry$seq)]] <- entry$data
+          if (!is.null(turn)) {
+            turns_map[[as.character(entry$seq)]] <- turn
           }
         }
       }
@@ -402,17 +506,30 @@ FileConversationStore <- R6::R6Class(
       ui_map <- list()
       ui_file <- file.path(cdir, "ui.jsonl")
       if (file.exists(ui_file)) {
-        for (line in readLines(ui_file, warn = FALSE)) {
+        lines <- readLines(ui_file, warn = FALSE)
+        for (line_number in seq_along(lines)) {
+          line <- lines[[line_number]]
           if (!nzchar(line)) {
             next
           }
-          entry <- tryCatch(
-            jsonlite::fromJSON(line, simplifyVector = FALSE),
-            error = function(e) NULL
-          )
-          if (!is.null(entry)) {
-            ui_map[[entry$node_id]] <- entry$data
+          entry <- history_parse_jsonl_line(line, ui_file, line_number)
+          if (
+            is.null(entry) ||
+              !is.list(entry) ||
+              !is.character(entry$node_id) ||
+              length(entry$node_id) != 1L ||
+              !is.list(entry$data)
+          ) {
+            if (!is.null(entry)) {
+              history_warn_malformed_jsonl(
+                ui_file,
+                line_number,
+                "expected node_id and data"
+              )
+            }
+            next
           }
+          ui_map[[entry$node_id]] <- entry$data
         }
       }
 
@@ -472,7 +589,10 @@ FileConversationStore <- R6::R6Class(
       }
       dir.create(cdir, recursive = TRUE, showWarnings = FALSE)
 
+      ws_key <- private$ws_key(partition, record$id)
+      had_write_state <- !is.null(private$write_state[[ws_key]])
       ws <- private$get_or_init_write_state(partition, record$id, cdir)
+      staged_ws <- unserialize(serialize(ws, NULL))
 
       new_turns_lines <- character(0)
       new_ui_lines <- character(0)
@@ -481,75 +601,43 @@ FileConversationStore <- R6::R6Class(
       for (nid in names(record$nodes)) {
         node <- record$nodes[[nid]]
 
-        if (is.null(ws$turn_seq_map[[nid]])) {
+        if (is.null(staged_ws$turn_seq_map[[nid]])) {
           turn_ids <- list()
           for (turn_data in node$turns) {
-            seq <- ws$next_turn_seq
-            ws$next_turn_seq <- ws$next_turn_seq + 1L
+            seq <- staged_ws$next_turn_seq
+            staged_ws$next_turn_seq <- staged_ws$next_turn_seq + 1L
             turn_ids <- c(turn_ids, seq)
             new_turns_lines <- c(
               new_turns_lines,
-              as.character(jsonlite::toJSON(
+              history_json(
                 list(
                   seq = seq,
                   data = jsonlite::serializeJSON(turn_data)
-                ),
-                auto_unbox = TRUE,
-                null = "null"
-              ))
+                )
+              )
             )
           }
-          ws$turn_seq_map[[nid]] <- turn_ids
+          staged_ws$turn_seq_map[[nid]] <- turn_ids
         }
 
-        ui_len <- length(node$ui)
-        if (!is.null(node$ui) && !identical(ui_len, ws$ui_node_len[[nid]])) {
-          new_ui_lines <- c(
-            new_ui_lines,
-            as.character(jsonlite::toJSON(
-              list(node_id = nid, data = node$ui),
-              auto_unbox = TRUE,
-              null = "null"
-            ))
-          )
-          ws$ui_node_len[[nid]] <- ui_len
+        if (!is.null(node$ui)) {
+          ui_digest <- history_json_digest(node$ui)
+          if (!identical(ui_digest, staged_ws$ui_node_digest[[nid]])) {
+            new_ui_lines <- c(
+              new_ui_lines,
+              history_json(list(node_id = nid, data = node$ui))
+            )
+            staged_ws$ui_node_digest[[nid]] <- ui_digest
+          }
         }
 
         record_nodes[[nid]] <- list(
           parent = node$parent,
           children = node$children,
-          turn_ids = ws$turn_seq_map[[nid]],
+          turn_ids = staged_ws$turn_seq_map[[nid]],
           selected_child = node$selected_child
         )
       }
-
-      turns_file <- file.path(cdir, "turns.jsonl")
-      if (length(new_turns_lines) > 0) {
-        cat(
-          paste0(new_turns_lines, collapse = "\n"),
-          "\n",
-          file = turns_file,
-          sep = "",
-          append = TRUE
-        )
-      } else if (!file.exists(turns_file)) {
-        file.create(turns_file)
-      }
-
-      ui_file <- file.path(cdir, "ui.jsonl")
-      if (length(new_ui_lines) > 0) {
-        cat(
-          paste0(new_ui_lines, collapse = "\n"),
-          "\n",
-          file = ui_file,
-          sep = "",
-          append = TRUE
-        )
-      } else if (!file.exists(ui_file)) {
-        file.create(ui_file)
-      }
-
-      private$write_state[[private$ws_key(partition, record$id)]] <- ws
 
       record_data <- list(
         schema_version = record$schema_version,
@@ -565,14 +653,52 @@ FileConversationStore <- R6::R6Class(
         values = record$values,
         bookmark_state_id = record$bookmark_state_id
       )
-      json <- jsonlite::toJSON(record_data, auto_unbox = TRUE, null = "null")
+      json <- history_json(record_data)
+
+      turns_file <- file.path(cdir, "turns.jsonl")
+      ui_file <- file.path(cdir, "ui.jsonl")
+      snapshots <- lapply(
+        list(turns_file, ui_file),
+        function(path) {
+          existed <- file.exists(path)
+          list(
+            path = path,
+            existed = existed,
+            size = if (existed) file.size(path) else 0
+          )
+        }
+      )
       tmp <- tempfile(tmpdir = cdir, fileext = ".json.tmp")
-      on.exit(unlink(tmp), add = TRUE)
-      writeLines(json, tmp)
+      committed <- FALSE
+      on.exit(
+        {
+          if (!committed) {
+            for (snapshot in rev(snapshots)) {
+              history_rollback_jsonl(
+                snapshot$path,
+                snapshot$existed,
+                snapshot$size
+              )
+            }
+            unlink(tmp)
+            if (!had_write_state) {
+              private$write_state[[ws_key]] <- NULL
+            }
+          }
+        },
+        add = TRUE
+      )
+
+      # Write and validate the replacement record before appending journals.
+      history_write_temp_record(json, tmp)
+      history_append_jsonl(turns_file, new_turns_lines)
+      history_append_jsonl(ui_file, new_ui_lines)
       ok <- file_move(tmp, record_file)
       if (!isTRUE(ok)) {
         rlang::abort(paste0("Failed to write conversation: ", cdir))
       }
+      committed <- TRUE
+      private$write_state[[ws_key]] <- staged_ws
 
       cache <- private$meta_cache[[key]]
       if (!is.null(cache)) {

--- a/pkg-r/R/chat_history_store.R
+++ b/pkg-r/R/chat_history_store.R
@@ -617,7 +617,7 @@ FileConversationStore <- R6::R6Class(
               history_json(
                 list(
                   seq = seq,
-                  data = jsonlite::serializeJSON(turn_data)
+                  data = jsonlite::serializeJSON(turn_data, digits = 17)
                 )
               )
             )

--- a/pkg-r/R/chat_history_store.R
+++ b/pkg-r/R/chat_history_store.R
@@ -287,6 +287,11 @@ resolve_history_dir <- function() {
 }
 
 #' File-based conversation storage backend
+#'
+#' Uses temporary records and journal rollback to protect against ordinary I/O
+#' failures, but does not fsync files or directories. This store also does not
+#' coordinate concurrent access across processes; callers must serialize reads
+#' and writes for each conversation.
 #' @export
 FileConversationStore <- R6::R6Class(
   "FileConversationStore",

--- a/pkg-r/man/FileConversationStore.Rd
+++ b/pkg-r/man/FileConversationStore.Rd
@@ -4,7 +4,10 @@
 \alias{FileConversationStore}
 \title{File-based conversation storage backend}
 \description{
-File-based conversation storage backend
+Uses temporary records and journal rollback to protect against ordinary I/O
+failures, but does not fsync files or directories. This store also does not
+coordinate concurrent access across processes; callers must serialize reads
+and writes for each conversation.
 }
 \section{Super class}{
 \code{\link[shinychat:ConversationStore]{ConversationStore}} -> \code{FileConversationStore}

--- a/pkg-r/tests/testthat/fixtures/history-store-fixture-matrix.json
+++ b/pkg-r/tests/testthat/fixtures/history-store-fixture-matrix.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "doubles_round_trip",
+    "value": 3.141592653589793
+  },
+  {
+    "name": "malformed_jsonl_line",
+    "line": "{not valid json"
+  },
+  {
+    "name": "grown_content_same_count",
+    "initial": "partial response",
+    "updated": "completed response"
+  }
+]

--- a/pkg-r/tests/testthat/test-chat_history_matrix.R
+++ b/pkg-r/tests/testthat/test-chat_history_matrix.R
@@ -6,7 +6,7 @@
 # fixtures/history-behavior-matrix.json because `R CMD check` builds this
 # package into an isolated tarball that doesn't contain anything outside
 # pkg-r/ — the vendored copy is kept in sync with the source by
-# `make history-matrix-sync`, and CI fails the build if it drifts (see
+# `make r-sync-fixtures`, and CI fails the build if it drifts (see
 # .github/workflows/verify-js-built.yaml).
 #
 # Only scenarios whose operation has a matching signature in both languages

--- a/pkg-r/tests/testthat/test-chat_history_store.R
+++ b/pkg-r/tests/testthat/test-chat_history_store.R
@@ -702,7 +702,7 @@ test_that("store fixture matrix: changed UI content with same count re-persists"
   expect_equal(restored$nodes$n_0001$ui, rec$nodes$n_0001$ui)
 })
 
-test_that("FileConversationStore rolls back journals when serialization fails", {
+test_that("FileConversationStore leaves files unchanged when serialization fails", {
   dir <- withr::local_tempdir()
   partition <- part()
   store <- FileConversationStore$new(dir = dir)

--- a/pkg-r/tests/testthat/test-chat_history_store.R
+++ b/pkg-r/tests/testthat/test-chat_history_store.R
@@ -2,6 +2,59 @@ part <- function(chat_id = "chat", scope = "user1") {
   conversation_partition(chat_id, scope)
 }
 
+store_fixture_matrix <- jsonlite::fromJSON(
+  test_path("fixtures", "history-store-fixture-matrix.json"),
+  simplifyVector = FALSE
+)
+
+store_fixture_case <- function(name) {
+  Filter(function(case) identical(case$name, name), store_fixture_matrix)[[1]]
+}
+
+store_conv_dir <- function(dir, partition, record) {
+  file.path(
+    dir,
+    sanitize_scope(partition$chat_id),
+    sanitize_scope(partition$scope),
+    record$id
+  )
+}
+
+store_file_snapshot <- function(path) {
+  files <- list.files(path, full.names = TRUE)
+  snapshot <- lapply(files, function(file) {
+    readBin(file, "raw", file.size(file))
+  })
+  names(snapshot) <- basename(files)
+  snapshot
+}
+
+store_test_record <- function() {
+  rec <- new_conversation_record("rollback")
+  rec$nodes$n_0001 <- list(
+    parent = NULL,
+    children = list(),
+    turns = list(list(role = "user", content = "first")),
+    ui = list(list(role = "user", segments = list())),
+    selected_child = NULL
+  )
+  rec$current_leaf <- "n_0001"
+  rec
+}
+
+store_test_record_add_node <- function(rec) {
+  rec$nodes$n_0001$children <- list("n_0002")
+  rec$nodes$n_0002 <- list(
+    parent = "n_0001",
+    children = list(),
+    turns = list(list(role = "assistant", content = "second")),
+    ui = list(list(role = "assistant", segments = list())),
+    selected_child = NULL
+  )
+  rec$current_leaf <- "n_0002"
+  rec
+}
+
 test_that("InMemoryConversationStore: put and get", {
   store <- InMemoryConversationStore$new()
   rec <- new_conversation_record("Test chat")
@@ -600,6 +653,110 @@ test_that("FileConversationStore re-appends a node's ui when it grows across sav
   fetched <- store$get(part(), rec$id)
   expect_length(fetched$nodes$n_0001$ui, 2)
   expect_equal(fetched$nodes$n_0001$ui[[2]]$segments[[1]]$content, "more")
+})
+
+test_that("store fixture matrix: doubles round-trip", {
+  case <- store_fixture_case("doubles_round_trip")
+  store <- FileConversationStore$new(dir = withr::local_tempdir())
+  rec <- new_conversation_record("doubles")
+  rec$values <- list(pi = case$value)
+
+  store$put(part(), rec)
+
+  expect_identical(store$get(part(), rec$id)$values$pi, case$value)
+})
+
+test_that("store fixture matrix: malformed jsonl lines warn visibly", {
+  case <- store_fixture_case("malformed_jsonl_line")
+  dir <- withr::local_tempdir()
+  partition <- part()
+  store <- FileConversationStore$new(dir = dir)
+  rec <- store_test_record()
+  store$put(partition, rec)
+  cdir <- store_conv_dir(dir, partition, rec)
+  turns_file <- file.path(cdir, "turns.jsonl")
+  cat(case$line, "\n", file = turns_file, append = TRUE, sep = "")
+
+  expect_warning(
+    result <- store$get(partition, rec$id),
+    paste0("turns.jsonl:2")
+  )
+  expect_equal(result$nodes$n_0001$turns, rec$nodes$n_0001$turns)
+})
+
+test_that("store fixture matrix: changed UI content with same count re-persists", {
+  case <- store_fixture_case("grown_content_same_count")
+  dir <- withr::local_tempdir()
+  store <- FileConversationStore$new(dir = dir)
+  rec <- store_test_record()
+  rec$nodes$n_0001$ui[[1]]$segments <- list(list(
+    content = case$initial,
+    content_type = "markdown"
+  ))
+  store$put(part(), rec)
+
+  rec$nodes$n_0001$ui[[1]]$segments[[1]]$content <- case$updated
+  store$put(part(), rec)
+
+  restored <- FileConversationStore$new(dir = dir)$get(part(), rec$id)
+  expect_equal(restored$nodes$n_0001$ui, rec$nodes$n_0001$ui)
+})
+
+test_that("FileConversationStore rolls back journals when serialization fails", {
+  dir <- withr::local_tempdir()
+  partition <- part()
+  store <- FileConversationStore$new(dir = dir)
+  rec <- store_test_record()
+  store$put(partition, rec)
+  cdir <- store_conv_dir(dir, partition, rec)
+  before <- store_file_snapshot(cdir)
+  rec <- store_test_record_add_node(rec)
+
+  testthat::local_mocked_bindings(
+    history_json = function(...) rlang::abort("injected serialization failure")
+  )
+  expect_error(store$put(partition, rec), "injected serialization failure")
+  expect_identical(store_file_snapshot(cdir), before)
+})
+
+test_that("FileConversationStore rolls back journals when an append fails", {
+  dir <- withr::local_tempdir()
+  partition <- part()
+  store <- FileConversationStore$new(dir = dir)
+  rec <- store_test_record()
+  store$put(partition, rec)
+  cdir <- store_conv_dir(dir, partition, rec)
+  before <- store_file_snapshot(cdir)
+  rec <- store_test_record_add_node(rec)
+
+  original_append <- history_append_jsonl
+  calls <- 0L
+  testthat::local_mocked_bindings(
+    history_append_jsonl = function(path, lines) {
+      calls <<- calls + 1L
+      original_append(path, lines)
+      if (calls == 2L) rlang::abort("injected append failure")
+    }
+  )
+  expect_error(store$put(partition, rec), "injected append failure")
+  expect_identical(store_file_snapshot(cdir), before)
+})
+
+test_that("FileConversationStore rolls back journals when rename fails", {
+  dir <- withr::local_tempdir()
+  partition <- part()
+  store <- FileConversationStore$new(dir = dir)
+  rec <- store_test_record()
+  store$put(partition, rec)
+  cdir <- store_conv_dir(dir, partition, rec)
+  before <- store_file_snapshot(cdir)
+  rec <- store_test_record_add_node(rec)
+
+  testthat::local_mocked_bindings(
+    file_move = function(...) FALSE
+  )
+  expect_error(store$put(partition, rec), "Failed to write conversation")
+  expect_identical(store_file_snapshot(cdir), before)
 })
 
 test_that("FileConversationStore preserves schema_version and children on round trip", {

--- a/pkg-r/tests/testthat/test-chat_history_store.R
+++ b/pkg-r/tests/testthat/test-chat_history_store.R
@@ -666,6 +666,20 @@ test_that("store fixture matrix: doubles round-trip", {
   expect_identical(store$get(part(), rec$id)$values$pi, case$value)
 })
 
+test_that("store fixture matrix: doubles in turns round-trip", {
+  case <- store_fixture_case("doubles_round_trip")
+  store <- FileConversationStore$new(dir = withr::local_tempdir())
+  rec <- store_test_record()
+  rec$nodes$n_0001$turns <- list(
+    list(role = "assistant", value = case$value)
+  )
+
+  store$put(part(), rec)
+
+  restored <- store$get(part(), rec$id)
+  expect_identical(restored$nodes$n_0001$turns[[1]]$value, case$value)
+})
+
 test_that("store fixture matrix: malformed jsonl lines warn visibly", {
   case <- store_fixture_case("malformed_jsonl_line")
   dir <- withr::local_tempdir()

--- a/tests/shared/history-store-fixture-matrix.json
+++ b/tests/shared/history-store-fixture-matrix.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "doubles_round_trip",
+    "value": 3.141592653589793
+  },
+  {
+    "name": "malformed_jsonl_line",
+    "line": "{not valid json"
+  },
+  {
+    "name": "grown_content_same_count",
+    "initial": "partial response",
+    "updated": "completed response"
+  }
+]


### PR DESCRIPTION
## Problem

FileConversationStore splits each conversation across a small `record.json` file and append-only turn/UI journals. The record references journal sequence IDs, so these files must advance as one logical update.

Previously, both implementations appended journal entries before serializing and replacing `record.json`. A serialization or rename failure could leave new journal data on disk that the record did not reference, while in-memory write state could prevent a safe retry. The UI write gate also compared only message counts, so changed content with the same count was not persisted. R's default JSON precision additionally truncated doubles.

## Solution

The store now prepares all serialized payloads before mutating journals, writes the replacement record to a temporary file, appends journals, then atomically replaces `record.json`. Append and rename failures restore both journals to their pre-write byte sizes and leave staged write state uncommitted.

UI persistence now uses a content digest instead of a message count. Journal reads remain tolerant of damaged entries but warn with the file and line number. R persisted JSON uses 17 significant digits for exact double round-trips.

The implementation documents its boundary: it protects against ordinary I/O failures, but does not provide power-loss durability or cross-process coordination.

## Verification

- `uv run pytest pkg-py/tests/test_history_store.py pkg-py/tests/test_history_matrix.py pkg-py/tests/test_history_types.py pkg-py/tests/test_history_controller.py -q` (`188 passed`)
- `cd pkg-r && Rscript -e "devtools::test(reporter = 'summary')"` (passed; 3 dependency skips and 2 existing warnings)
- `uv run ruff check pkg-py --config pyproject.toml`
- `uv run pyright`
- `air format --check pkg-r/`