### PR TITLE
agents-md: Slim advice to `make help`, add filtering to test targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,74 +34,20 @@ and storage keys. New raw-HTML islands use `<shiny-chat-raw-html>`; preserve
 `<shinychat-raw-html>` only as a legacy input until its compatibility window
 closes.
 
-## Common Development Commands
+## Development Workflow
 
-### JavaScript (js/)
-- **Setup**: `cd js && npm install`
-- **Build**: `cd js && npm run build` (lint + bundle)
-- **Lint**: `cd js && npm run lint` (TypeScript check + ESLint)
-- **Watch**: `cd js && npm run watch` (rebuild on file changes)
-- **Fast build/watch**: Use `build-fast` and `watch-fast` targets (skip minification)
-
-### Python (pkg-py/)
-- **Setup**: `uv sync --all-extras`
-- **Lint**: `uv run ruff check pkg-py --config pyproject.toml`
-- **Format**: `uv run ruff check --fix pkg-py --config pyproject.toml && uv run ruff format pkg-py --config pyproject.toml`
-- **Type check**: `uv run pyright`
-- **Test**: `uv run pytest` (requires `uv run playwright install` first)
-- **Build**: `uv build`
-- **Coverage**: `uv run coverage run -m pytest && uv run coverage report`
-
-### R (pkg-r/)
-- **Setup**: `cd pkg-r && Rscript -e "pak::local_install_dev_deps()"`
-- **Document**: `cd pkg-r && Rscript -e "devtools::document()"`
-- **Check**: `cd pkg-r && Rscript -e "devtools::check(document = FALSE)"`
-- **Test**: `cd pkg-r && Rscript -e "devtools::test()"`
-- **Format**: `air format pkg-r/` (check with `air format --check pkg-r/`)
-
-### Makefile Targets
-The repository includes a comprehensive Makefile with prefixed targets:
-- **js-\***: JavaScript tasks (`js-build`, `js-lint`, `js-setup`)
-- **py-\***: Python tasks (`py-check`, `py-format`, `py-test`)
-- **r-\***: R tasks (`r-check`, `r-format`, `r-test`)
-- **docs**: Build all documentation
-- Run `make help` to see all available targets
+Run `make help` from the repository root before choosing a development,
+testing, build, or documentation command. Prefer the listed Make targets over
+their underlying package-manager commands. Target help text documents supported
+arguments, including test filters.
 
 ### Asset Distribution
-**CRITICAL**: The Python and R packages serve JS/CSS from their own copy of the built assets, NOT from `js/dist/` directly. After ANY change to TypeScript or SCSS files in `js/`, you MUST:
-1. Rebuild: `cd js && npm run build`
-2. Copy to packages: `make py-update-dist r-update-dist`
-3. Include the updated dist files in your commit
 
-If you skip step 2, the packages will serve stale JS and your changes will not take effect at runtime. This applies to renaming, adding features, fixing bugs — any JS/SCSS change at all.
+**CRITICAL**: The Python and R packages serve JS/CSS from their own copy of the built assets, NOT from `js/dist/` directly. After ANY change to TypeScript or SCSS files in `js/`, you MUST rebuild and copy to packages with `make update-dist`.
 
-## Testing
+If you skip this step, the packages will serve stale JS and your changes will not take effect at runtime. This applies to renaming, adding features, fixing bugs — any JS/SCSS change at all.
 
-### Python
-- Main tests: `uv run pytest`
-- Playwright browser tests included (requires `uv run playwright install`)
-- Tox for multi-version testing: `uv run tox run-parallel` (Python 3.9-3.13)
-- Snapshot updates: `uv run pytest --snapshot-update`
-
-### R
-- Tests: `cd pkg-r && Rscript -e "devtools::test()"`
-- R CMD check: `cd pkg-r && Rscript -e "devtools::check(document = FALSE)"`
-
-### JavaScript
-- Linting includes TypeScript compilation check: `cd js && npm run lint`
-
-## Documentation
-
-### Python Docs
-- Built with Quarto + quartodoc
-- **Build API docs**: `cd pkg-py/docs && uv run quartodoc build`
-- **Render docs**: `make py-docs-render` (uses Quarto)
-- **Preview**: `make py-docs-preview`
-
-### R Docs
-- Built with pkgdown
-- **Build**: `cd pkg-r && Rscript -e "pkgdown::build_site()"`
-- **Preview**: `cd pkg-r && Rscript -e "pkgdown::preview_site()"`
+Commit source files indepentently of built asset updates. You can wait to commit asset updates until the end of a PR or work cycle.
 
 ## Key Files
 

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,20 @@ js-build-dev:  ## [js] Build JS code for development (React Profiler enabled)
 	@echo "🧳 Building JS code (dev)"
 	cd $(PATH_PKG_JS) && npx tsx build.ts --dev
 
+.PHONY: js-build-fast
+js-build-fast:  ## [js] Build JS code without minification
+	@echo "🧳 Building JS code without minification"
+	cd $(PATH_PKG_JS) && npm run build-fast
+
 .PHONY: js-build-watch
 js-build-watch:  ## [js] Build JS code in watch mode
 	@echo "🧳 Building JS code in watch mode"
 	cd $(PATH_PKG_JS) && npm run watch
+
+.PHONY: js-build-watch-fast
+js-build-watch-fast:  ## [js] Build JS code without minification in watch mode
+	@echo "🧳 Building JS code without minification in watch mode"
+	cd $(PATH_PKG_JS) && npm run watch-fast
 
 .PHONY: update-dist
 update-dist: js-build r-update-dist py-update-dist  ## Update shinychat web assets in all packages
@@ -93,10 +103,10 @@ r-check-package:  ## [r] Check package
 	cd $(PATH_PKG_R) && Rscript -e "devtools::check(document = FALSE)"
 
 .PHONY: r-check-tests
-r-check-tests:  ## [r] Check tests
+r-check-tests:  ## [r] Check tests (FILTER=... to select tests)
 	@echo ""
 	@echo "🧪 Running R tests"
-	cd $(PATH_PKG_R) && Rscript -e "devtools::test()"
+	cd $(PATH_PKG_R) && FILTER="$(FILTER)" Rscript -e 'filter <- Sys.getenv("FILTER"); devtools::test(filter = if (nzchar(filter)) filter else NULL)'
 
 .PHONY: r-check-format
 r-check-format:  ## [r] Check format
@@ -152,12 +162,12 @@ py-check-tox:  ## [py] Run python checks across versions with tox
 	uv run tox run-parallel
 
 .PHONY: py-check-tests
-py-check-tests:  ## [py] Run python tests
+py-check-tests:  ## [py] Run python tests (FILTER=... for pytest -k selection)
 	@echo ""
 	@echo "🧪 Running tests with pytest"
 	uv run playwright install
-	uv run pytest pkg-py/tests/playwright/
-	uv run pytest --ignore=pkg-py/tests/playwright/
+	uv run pytest pkg-py/tests/playwright/ $(if $(FILTER),-k "$(FILTER)")
+	uv run pytest --ignore=pkg-py/tests/playwright/ $(if $(FILTER),-k "$(FILTER)")
 
 .PHONY: py-check-types
 py-check-types:  ## [py] Run python type checks

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ py-update-dist: ## [py] Update shinychat web assets
 .PHONY: help
 help:  ## Show help messages for make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; { \
-		printf "\033[32m%-18s\033[0m", $$1; \
+		printf "\033[32m%-19s\033[0m", $$1; \
 		if ($$2 ~ /^\[docs\]/) { \
 			printf "\033[37m[docs]\033[0m%s\n", substr($$2, 7); \
 		} else if ($$2 ~ /^\[py\]/) { \


### PR DESCRIPTION
Replaces the many commands mentioned in AGENTS.md with a direct pointer to `make help`, which reproduces the same advice.
