### PR TITLE
fix(py): tear down ChatHistory on same-ID Chat reconstruction

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -2006,6 +2006,7 @@ class Chat:
         """
         self._destroy_effects()
         self._destroy_bookmarking()
+        self.history._teardown()
 
     def _destroy_effects(self):
         for x in self._effects:

--- a/pkg-py/src/shinychat/_history.py
+++ b/pkg-py/src/shinychat/_history.py
@@ -38,6 +38,7 @@ from ._history_types import (
 if TYPE_CHECKING:
     from htmltools import HTML, Tag, TagList
     from shiny.module import ResolvedId
+    from shiny.reactive._reactives import Effect_
 
     from ._chat import Chat
     from ._chat_types import ChatGreeting
@@ -708,6 +709,12 @@ class ChatHistory:
         self._controller: HistoryController | None = None
         self._save_callbacks: "list[Callable[[dict[str, Any]], None]]" = []
         self._restore_callbacks: "list[Callable[[dict[str, Any]], None]]" = []
+        # Session-level registrations made by `_start()`, tracked so they can
+        # be released when the owning Chat is destroyed (e.g. same-id
+        # reconstruction) instead of leaking until session end.
+        self._effects: "list[Effect_]" = []
+        self._session_end_cancel: "Callable[[], None] | None" = None
+        self._on_session_end: "Callable[[], None] | None" = None
         cfg = config if config is not None else HistoryOptions()
         self._store: "ConversationStore | Literal['auto', 'memory', 'file']" = (
             cfg.store
@@ -723,6 +730,29 @@ class ChatHistory:
         """Enable chat history for the current session. No-op if already started."""
         if not self._started:
             self._start()
+
+    def _teardown(self) -> None:
+        """
+        Release session-level registrations when the owning `Chat` is destroyed
+        or replaced by a same-id reconstruction.
+
+        Destroys the history input effects — which otherwise keep answering the
+        shared input ids and retain the old controller for the rest of the
+        session — unregisters the session-end callback, and runs the cleanup
+        that session end would have run. No-op if history never started; safe
+        to call more than once.
+        """
+        for effect in self._effects:
+            effect.destroy()
+        self._effects.clear()
+        cancel = self._session_end_cancel
+        self._session_end_cancel = None
+        if cancel is not None:
+            cancel()
+        on_end = self._on_session_end
+        self._on_session_end = None
+        if on_end is not None:
+            on_end()
 
     async def save(self) -> bool:
         """
@@ -1153,9 +1183,26 @@ class ChatHistory:
                 await notify_error("Could not navigate messages", e)
 
         def _on_session_end() -> None:
+            # The session consumed the registration by firing it; keep the
+            # tracked state truthful so a later `_teardown()` won't re-run.
+            self._session_end_cancel = None
+            self._on_session_end = None
             if stamp_cancel is not None:
                 stamp_cancel()
             controller.cancel_pending()
 
-        session.on_ended(_on_session_end)
+        self._effects.extend(
+            [
+                _init_history,
+                _save_on_response,
+                _on_select,
+                _on_new,
+                _on_rename,
+                _on_delete,
+                _on_edit,
+                _on_navigate,
+            ]
+        )
+        self._on_session_end = _on_session_end
+        self._session_end_cancel = session.on_ended(_on_session_end)
         self._started = True

--- a/pkg-py/tests/test_chat_history.py
+++ b/pkg-py/tests/test_chat_history.py
@@ -26,8 +26,8 @@ class _MockSession:
 
         self.input = Inputs({}, ns=ResolvedId)
 
-    def on_ended(self, callback: object) -> None:
-        pass
+    def on_ended(self, callback: Callable[[], None]) -> Callable[[], None]:
+        return lambda: None
 
     def on_destroy(self, callback: object) -> None:
         pass
@@ -229,3 +229,143 @@ async def test_setup_greeting_wires_on_settled():
         mock_resolve.reset_mock()
         await fake_controller.on_settled(True)
         mock_resolve.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Same-id reconstruction / session teardown (shinychat#wsmt)
+# ---------------------------------------------------------------------------
+
+
+class _MockBookmark:
+    def __init__(self) -> None:
+        self.exclude: list[str] = []
+        self.store = "disable"
+        self._restore_context = None
+
+
+class _LiveSession(_MockSession):
+    """Non-stub session mock with just enough surface to run ChatHistory._start()."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bookmark = _MockBookmark()
+        self.ended_callbacks: list[Callable[[], None]] = []
+
+    def is_stub_session(self) -> bool:
+        return False
+
+    def root_scope(self) -> "_LiveSession":
+        return self
+
+    def on_ended(self, callback: Callable[[], None]) -> Callable[[], None]:
+        self.ended_callbacks.append(callback)
+
+        def _unregister() -> None:
+            if callback in self.ended_callbacks:
+                self.ended_callbacks.remove(callback)
+
+        return _unregister
+
+    def _decrement_busy_count(self) -> None:
+        pass
+
+    async def send_custom_message(self, type: str, message: object) -> None:
+        pass
+
+
+class _MockClient:
+    """Minimal ClientWithTurns stand-in; history requires turn-level access."""
+
+    def __init__(self) -> None:
+        self._turns: list[Any] = []
+
+    def get_turns(self) -> list[Any]:
+        return list(self._turns)
+
+    def set_turns(self, turns: list[Any]) -> None:
+        self._turns = list(turns)
+
+
+def _make_live_chat(id: str, session: Any) -> Chat:
+    with session_context(session):
+        return Chat(
+            id,
+            client=cast(Any, _MockClient()),
+            history=HistoryOptions(store="memory"),
+        )
+
+
+def _registered_history_cleanups(session: Any) -> list[Callable[[], None]]:
+    return [
+        cb
+        for cb in session.ended_callbacks
+        if getattr(cb, "__name__", "") == "_on_session_end"
+    ]
+
+
+def test_same_id_reconstruction_tears_down_prior_history():
+    session = cast(Any, _LiveSession())
+    chat1 = _make_live_chat("recon", session)
+    history1 = chat1.history
+    assert history1._controller is not None
+    on_end1 = history1._on_session_end
+    assert on_end1 in session.ended_callbacks
+    effects1 = list(history1._effects)
+    assert len(effects1) > 0
+    cancel_pending1 = MagicMock()
+    history1._controller.cancel_pending = cancel_pending1  # type: ignore[method-assign]
+
+    chat2 = _make_live_chat("recon", session)
+
+    # The replaced history unregistered its session-end callback, ran its
+    # cleanup, and destroyed its input effects...
+    assert history1._on_session_end is None
+    assert history1._session_end_cancel is None
+    assert history1._effects == []
+    assert all(e._destroyed for e in effects1)
+    cancel_pending1.assert_called_once()
+    assert on_end1 not in session.ended_callbacks
+    # ...leaving the replacement as the sole live history registration.
+    assert chat2.history._controller is not None
+    assert _registered_history_cleanups(session) == [
+        chat2.history._on_session_end
+    ]
+
+
+def test_repeated_same_id_reconstruction_retains_single_registration():
+    session = cast(Any, _LiveSession())
+    chats = [_make_live_chat("repeat", session) for _ in range(3)]
+
+    for chat in chats[:-1]:
+        assert chat.history._on_session_end is None
+        assert chat.history._session_end_cancel is None
+        assert chat.history._effects == []
+    assert _registered_history_cleanups(session) == [
+        chats[-1].history._on_session_end
+    ]
+
+
+def test_session_end_runs_history_cleanup_once():
+    session = cast(Any, _LiveSession())
+    chat = _make_live_chat("teardown", session)
+    history = chat.history
+    controller = history._controller
+    assert controller is not None
+    cancel_pending = MagicMock()
+    controller.cancel_pending = cancel_pending  # type: ignore[method-assign]
+
+    # Simulate session teardown: fire every registered on_ended callback.
+    for cb in list(session.ended_callbacks):
+        cb()
+
+    cancel_pending.assert_called_once()
+    assert history._session_end_cancel is None
+    assert history._on_session_end is None
+    # A later Chat.destroy() must not re-run the cleanup.
+    chat.destroy()
+    cancel_pending.assert_called_once()
+
+
+def test_chat_destroy_without_history_start_is_safe():
+    chat = _make_chat(history=False)
+    chat.destroy()  # no session-level registrations to release


### PR DESCRIPTION
## Context

In Shiny for Python, a dynamic `Chat` can be reconstructed with the same id within a session (e.g. when dynamic UI re-renders). `Chat.__init__` guards against duplicate registrations with `CHAT_INSTANCES`: the previous instance is popped and `destroy()`ed before the new one registers.

## The bug

`Chat.destroy()` tore down the chat's own effects and bookmarking, but not its `ChatHistory`. `ChatHistory._start()` registered its `_on_session_end` cleanup with `session.on_ended()` and discarded the returned unregister callback, and none of its eight reactive effects (history init, save-on-response, and the select/new/rename/delete/edit/navigate input handlers) were tracked anywhere.

So on each same-ID reconstruction, the old history's input effects stayed **active** on the same input ids — both the stale and the replacement controller would answer select/new/rename/etc., racing to drive the same client chat element — and the old controller and its closures stayed **retained** by the session until session end.

## The fix

- `ChatHistory` now tracks its effects and the `on_ended` unregister callback.
- New `ChatHistory._teardown()` destroys the effects, unregisters the session-end callback, and runs the cleanup session end would have run (bookmark-stamp cancel + `controller.cancel_pending()`). No-op if history never started; safe to call twice.
- `Chat.destroy()` now calls `self.history._teardown()`.
- The session-end closure nulls the tracked handles when it fires, so a `destroy()` after session end doesn't re-run cleanup.

Note that destroying the effects (not just unregistering the session-end callback) is load-bearing — without it the old controller stays live on the shared input ids. One known residual: py-shiny itself registers every effect's `destroy()` with `session.on_ended()` as a strong reference and discards *that* unregister callback, so destroyed effect shells remain session-retained until session end regardless of what we do here. That's platform behavior in py-shiny, out of scope for this PR.

## Verification

New regression tests in `pkg-py/tests/test_chat_history.py` (run against a minimal non-stub mock session that actually executes `ChatHistory._start()`): same-ID reconstruction unregisters the prior history's session-end callback, destroys its effects, and runs `cancel_pending()`; repeated (3x) reconstruction retains exactly one history registration; simulated session teardown runs cleanup exactly once, even with a later `Chat.destroy()`; and `destroy()` is safe when history never started.

The two reconstruction tests fail on the unfixed code (verified by stashing the fix). Full Python unit suite: 542 passed. pyright: 0 errors.