### PR TITLE
fix(py): deterministic MIME resolution for text attachment extensions

### DIFF
--- a/pkg-py/src/shinychat/_attachments.py
+++ b/pkg-py/src/shinychat/_attachments.py
@@ -49,6 +49,24 @@ SUPPORTED_ATTACHMENT_TYPES: tuple[str, ...] = (
 )
 
 
+def _guess_mime(name: str) -> str:
+    """Guess a MIME type from a filename or URL, deterministically.
+
+    The package's own extension→MIME mapping (``attachment-types.json``) is
+    consulted first so that supported text-attachment extensions resolve
+    consistently across platforms — the platform ``mimetypes`` database is
+    unreliable for extensions like ``.md``, ``.qmd``, and ``.yaml``.  Unknown
+    extensions fall through to ``mimetypes.guess_type``, then to
+    ``application/octet-stream``.
+    """
+    ext = Path(name).suffix.lower().lstrip(".")
+    return (
+        _TYPES["text_extensions"].get(ext)
+        or mimetypes.guess_type(name)[0]
+        or "application/octet-stream"
+    )
+
+
 class Attachment(BaseModel):
     """An image, PDF, or text file to attach to a chat message.
 
@@ -75,11 +93,7 @@ class Attachment(BaseModel):
         """Create an attachment from a filesystem path."""
         p = Path(path)
         raw = p.read_bytes()
-        resolved_mime = (
-            mime
-            or mimetypes.guess_type(p.name)[0]
-            or "application/octet-stream"
-        )
+        resolved_mime = mime or _guess_mime(p.name)
         return cls(
             mime=resolved_mime,
             name=name or p.name,
@@ -130,9 +144,7 @@ class Attachment(BaseModel):
                 size=len(raw),
                 data_url=url,
             )
-        resolved_mime = (
-            mime or mimetypes.guess_type(url)[0] or "application/octet-stream"
-        )
+        resolved_mime = mime or _guess_mime(url)
         return cls(
             mime=resolved_mime,
             name=name or "",

--- a/pkg-py/tests/pytest/test_attachments.py
+++ b/pkg-py/tests/pytest/test_attachments.py
@@ -295,3 +295,49 @@ def test_attachment_from_path(tmp_path):
     assert a.name == "note.md"
     assert a.mime == "text/markdown"
     assert a.size == 4
+
+
+def test_attachment_from_path_md_mime_independent_of_platform(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    """``.md`` must resolve to ``text/markdown`` even when the platform MIME
+    database returns ``application/octet-stream`` (as on some macOS/Python
+    combinations)."""
+    monkeypatch.setattr(
+        "shinychat._attachments.mimetypes",
+        type(
+            "_StubMimetypes",
+            (),
+            {
+                "guess_type": staticmethod(
+                    lambda name: ("application/octet-stream", None)
+                ),
+            },
+        ),
+    )
+    p = tmp_path / "note.md"
+    p.write_text("# hi")
+    a = Attachment.from_path(str(p))
+    assert a.mime == "text/markdown"
+
+
+def test_attachment_from_path_explicit_mime_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    """An explicit ``mime=`` argument takes precedence over the extension
+    mapping."""
+    p = tmp_path / "note.md"
+    p.write_text("# hi")
+    a = Attachment.from_path(str(p), mime="text/plain")
+    assert a.mime == "text/plain"
+
+
+def test_attachment_from_path_qmd_resolves_markdown(tmp_path):
+    """``.qmd`` is not in the platform MIME database but should resolve to
+    ``text/markdown`` via the package mapping."""
+    p = tmp_path / "doc.qmd"
+    p.write_text("content")
+    a = Attachment.from_path(str(p))
+    assert a.mime == "text/markdown"


### PR DESCRIPTION
## Summary

`Attachment.from_path()` and `Attachment.from_url()` relied solely on `mimetypes.guess_type()` to resolve file extensions to MIME types. This is platform-dependent: on some macOS/Python combinations `.md` resolves to `application/octet-stream` instead of `text/markdown`, `.qmd`/`.rmd` return `None` entirely, and `.yaml` returns `application/yaml` (which isn't in `SUPPORTED_ATTACHMENT_TYPES`) instead of the expected `text/yaml`.

The fix adds a `_guess_mime()` helper that consults the package's own extension-to-MIME mapping (`attachment-types.json` → `text_extensions`) before falling back to the platform `mimetypes` database. This makes MIME resolution deterministic for all supported text-attachment extensions while preserving explicit `mime=` caller precedence (the keyword argument still wins).

## Changes

- **`pkg-py/src/shinychat/_attachments.py`**: Added `_guess_mime()` helper that checks `text_extensions` first, then `mimetypes.guess_type()`, then `application/octet-stream`. Updated `from_path()` and `from_url()` to use it.
- **`pkg-py/tests/pytest/test_attachments.py`**: Added three regression tests (see below).

## Verification

```python
from shinychat import Attachment
from pathlib import Path

# .md resolves to text/markdown regardless of platform
p = Path("note.md"); p.write_text("# hi")
att = Attachment.from_path(str(p))
assert att.mime == "text/markdown"  # not application/octet-stream

# Explicit mime= still takes precedence
att = Attachment.from_path(str(p), mime="text/plain")
assert att.mime == "text/plain"

# .qmd (not in platform MIME DB) resolves via package mapping
p2 = Path("doc.qmd"); p2.write_text("content")
att = Attachment.from_path(str(p2))
assert att.mime == "text/markdown"
```

Run the test suite:

```bash
make py-check-tests FILTER="test_attachment_from_path"
```

All 285 Python tests pass, 0 pyright errors.
