### PR TITLE
fix: client_set_ui() no longer iterates over htmlwidgets

### DIFF
--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     lifecycle,
     promises (>= 1.3.2),
     R6 (>= 2.5.0),
-    rlang (>= 1.1.0),
+    rlang (>= 1.2.0),
     S7,
     shiny (>= 1.10.0)
 Suggests:

--- a/pkg-r/R/client_state.R
+++ b/pkg-r/R/client_state.R
@@ -87,8 +87,7 @@ method(client_set_ui, S7::new_S3_class(c("Chat", "R6"))) <-
 
     msgs <- contents_shinychat(client)
     lapply(msgs, function(msg_turn) {
-      is_list <- is.list(msg_turn$content) &&
-        !inherits(msg_turn$content, c("shiny.tag", "shiny.taglist"))
+      is_list <- is_bare_list(msg_turn$content)
 
       if (is_list) {
         stream <- coro::generator(function() {

--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -776,7 +776,7 @@ get_tool_result_display <- function(content) {
   )
 
   if (
-    inherits(display, c("html", "shiny.tag", "shiny.tag.list", "htmlwidgets"))
+    inherits(display, c("html", "shiny.tag", "shiny.tag.list", "htmlwidget"))
   ) {
     cli::cli_warn(
       c(


### PR DESCRIPTION
Closes #362

## Summary

`client_set_ui()` decides whether to replay a message's content item-by-item with this check:

```r
is_list <- is.list(msg_turn$content) &&
  !inherits(msg_turn$content, c("shiny.tag", "shiny.taglist"))
```

Two bugs:

1. **`"shiny.taglist"` is misspelled** — the class is `"shiny.tag.list"`. `shiny.tag.list` objects passed the check and got iterated field-by-field instead of being appended whole.
2. **htmlwidget not excluded** — an htmlwidget is a classed list (`c("htmlwidget", "list")`), so it passed the check and got iterated over its internal fields (`x`, `width`, `sizingPolicy`, ...). Restoring a chat whose messages contain an htmlwidget would break.

Replaced the fragile exclusion-list check with `rlang::is_bare_list()`, which returns `TRUE` only for plain, classless lists — exactly the case where item-by-item iteration is intended.

Also fixed `"htmlwidgets"` to `"htmlwidget"` in `get_tool_result_display()` (`R/contents_shinychat.R`), so raw htmlwidgets passed as `@extra$display` trigger the intended warning.

Unrelated: bumped rlang dependency to `>= 1.2.0` for `check_string()`.
