### PR TITLE
fix: avoid native pipe in R package

### DIFF
--- a/pkg-r/R/chat_history_title.R
+++ b/pkg-r/R/chat_history_title.R
@@ -63,12 +63,14 @@ generate_title <- function(title_fn, client, recorded_turns) {
       )
       excerpt_text <- paste(excerpt, collapse = "\n\n")
 
-      titler$chat_async(excerpt_text) |>
-        promises::then(normalize_title) |>
-        promises::catch(function(e) {
-          rlang::warn("Title generation failed", parent = e)
-          NULL
-        })
+      title_promise <- promises::then(
+        titler$chat_async(excerpt_text),
+        normalize_title
+      )
+      promises::catch(title_promise, function(e) {
+        rlang::warn("Title generation failed", parent = e)
+        NULL
+      })
     },
     error = function(e) {
       rlang::warn("Title generation failed", parent = e)


### PR DESCRIPTION
## Summary
Replace the native `|>` chain in title generation with explicit `promises::then()` and `promises::catch()` calls so the package does not require a newer R version.

## Verification
- `make r-check-tests FILTER=chat_history`
- `air format --check R/chat_history_title.R`
- R parse check