### PR TITLE
fix: silently drop NULL fields in tool result display lists

### DIFF
--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -836,8 +836,6 @@ as_tool_result_display <- function(display, error_context = NULL) {
     return(structure(list(), class = "shinychat_tool_result_display"))
   }
 
-  # Named NULLs arise from idiomatic conditional fields like
-  # `list(title = if (cond) title)`; treat them as absent.
   display <- display[!map_lgl(display, is.null)]
 
   unknown <- setdiff(names(display), tool_result_display_fields)

--- a/pkg-r/R/contents_shinychat.R
+++ b/pkg-r/R/contents_shinychat.R
@@ -836,6 +836,10 @@ as_tool_result_display <- function(display, error_context = NULL) {
     return(structure(list(), class = "shinychat_tool_result_display"))
   }
 
+  # Named NULLs arise from idiomatic conditional fields like
+  # `list(title = if (cond) title)`; treat them as absent.
+  display <- display[!map_lgl(display, is.null)]
+
   unknown <- setdiff(names(display), tool_result_display_fields)
   if (length(unknown) > 0) {
     cli::cli_warn(

--- a/pkg-r/tests/testthat/test-contents_shinychat.R
+++ b/pkg-r/tests/testthat/test-contents_shinychat.R
@@ -1010,9 +1010,6 @@ test_that("as_tool_result_display() rejects non-scalar and NA logicals", {
 })
 
 test_that("as_tool_result_display() silently drops NULL fields", {
-  # `list(title = if (cond) title)` is an idiomatic way for tool authors to
-  # conditionally include a field; it yields a named NULL that should be
-  # treated as absent, not as an invalid value.
   expect_no_warning(
     res <- as_tool_result_display(list(title = NULL, open = TRUE))
   )

--- a/pkg-r/tests/testthat/test-contents_shinychat.R
+++ b/pkg-r/tests/testthat/test-contents_shinychat.R
@@ -1009,6 +1009,28 @@ test_that("as_tool_result_display() rejects non-scalar and NA logicals", {
   expect_null(res$show_request)
 })
 
+test_that("as_tool_result_display() silently drops NULL fields", {
+  # `list(title = if (cond) title)` is an idiomatic way for tool authors to
+  # conditionally include a field; it yields a named NULL that should be
+  # treated as absent, not as an invalid value.
+  expect_no_warning(
+    res <- as_tool_result_display(list(title = NULL, open = TRUE))
+  )
+  expect_s3_class(res, "shinychat_tool_result_display")
+  expect_null(res$title)
+  expect_true(res$open)
+
+  expect_no_warning(
+    res <- as_tool_result_display(list(
+      title = NULL,
+      show_request = NULL,
+      markdown = "content"
+    ))
+  )
+  expect_equal(res$markdown, "content")
+  expect_false(any(c("title", "show_request") %in% names(res)))
+})
+
 test_that("as_tool_result_display() keeps valid logical flags", {
   res <- as_tool_result_display(
     list(show_request = FALSE, open = TRUE, full_screen = TRUE)


### PR DESCRIPTION
## Problem

`as_tool_result_display()` warns on `NULL` field values, but named NULLs are an idiomatic R byproduct of conditionally including a field:

```r
# Tool author wants a title only for some actions
display = list(
  title = if (action == "update") title,  # NULL when action != "update"
  markdown = md,
  open = TRUE
)
```

This produces a named `NULL` (`list(title = NULL, ...)`), which fails field validation:

```
Warning: Invalid `@extra$display` format for `ContentToolResult` from `querychat_query()` ...
x title must be a single string or HTML content, not NULL; ignoring.
```

Seen in the wild with querychat's `querychat_query` tool.

## Repro

```r
shinychat:::as_tool_result_display(list(title = NULL, open = TRUE))
# Before: warning "title must be a single string or HTML content, not NULL; ignoring."
# After:  no warning; title treated as absent
```

## Fix

Drop `NULL` fields at the top of `as_tool_result_display()`, before unknown/invalid field validation. Genuinely invalid values (wrong type, `NA`, non-scalar) still warn as before.