### PR TITLE
fix(r): save chat history when the assistant calls tools

### DIFF
--- a/pkg-r/R/chat_history_store.R
+++ b/pkg-r/R/chat_history_store.R
@@ -190,7 +190,10 @@ history_json <- function(value) {
     value,
     auto_unbox = TRUE,
     null = "null",
-    digits = 17
+    digits = 17,
+    # Unclass shinychat_block segments (and any other classed values hiding
+    # at any depth) so asJSON dispatch doesn't fail on them.
+    force = TRUE
   ))
 }
 

--- a/pkg-r/R/chat_history_store.R
+++ b/pkg-r/R/chat_history_store.R
@@ -191,8 +191,6 @@ history_json <- function(value) {
     auto_unbox = TRUE,
     null = "null",
     digits = 17,
-    # Unclass shinychat_block segments (and any other classed values hiding
-    # at any depth) so asJSON dispatch doesn't fail on them.
     force = TRUE
   ))
 }

--- a/pkg-r/tests/testthat/test-chat_history_store.R
+++ b/pkg-r/tests/testthat/test-chat_history_store.R
@@ -1011,3 +1011,83 @@ test_that("safe_conv_path() rejects path traversal", {
   expect_error(safe_conv_path(tempdir(), "../../../etc/passwd"))
   expect_error(safe_conv_path(tempdir(), ""))
 })
+
+test_that("history_json() serializes stored messages with classed tool blocks", {
+  # Regression test: as.list() on a classed list retains its class, so
+  # shinychat_block segments used to reach jsonlite::toJSON() classed and
+  # error with "No method asJSON S3 class: shinychat_block".
+  tool_result <- ellmer::ContentToolResult(
+    request = ellmer::ContentToolRequest(
+      id = "t1",
+      name = "rnorm",
+      arguments = list(n = 3)
+    ),
+    value = "0.1, 0.2"
+  )
+  card <- contents_shinychat_wrapped(tool_result)
+  expect_s3_class(card, "shinychat_block")
+
+  ui_msg <- build_stored_message_from_content("assistant", list(card))
+
+  json <- history_json(ui_msg)
+  decoded <- jsonlite::fromJSON(json, simplifyVector = FALSE)
+  seg_types <- vapply(
+    decoded$segments,
+    function(seg) seg$type %||% "",
+    character(1)
+  )
+  expect_true("tool_result" %in% seg_types)
+})
+
+test_that("history_json() serializes stored messages with classed html blocks", {
+  block <- new_html_block("<p>hello</p>")
+  expect_s3_class(block, "shinychat_block")
+
+  ui_msg <- build_stored_message_from_content("assistant", list(block))
+
+  json <- history_json(ui_msg)
+  decoded <- jsonlite::fromJSON(json, simplifyVector = FALSE)
+  seg_types <- vapply(
+    decoded$segments,
+    function(seg) seg$type %||% "",
+    character(1)
+  )
+  expect_true("html_block" %in% seg_types)
+})
+
+test_that("FileConversationStore round-trips a record with classed block segments", {
+  tool_result <- ellmer::ContentToolResult(
+    request = ellmer::ContentToolRequest(
+      id = "t1",
+      name = "rnorm",
+      arguments = list(n = 3)
+    ),
+    value = "0.1, 0.2"
+  )
+  card <- contents_shinychat_wrapped(tool_result)
+  ui_msg <- build_stored_message_from_content("assistant", list(card))
+
+  dir <- withr::local_tempdir()
+  partition <- part()
+  store <- FileConversationStore$new(dir = dir)
+  rec <- new_conversation_record("tool call chat")
+  rec$nodes$n_0001 <- list(
+    parent = NULL,
+    children = list(),
+    turns = list(
+      list(role = "user", content = "roll some dice"),
+      list(role = "assistant", content = "0.1, 0.2")
+    ),
+    ui = list(ui_msg),
+    selected_child = NULL
+  )
+  rec$current_leaf <- "n_0001"
+
+  expect_no_error(store$put(partition, rec))
+
+  restored <- FileConversationStore$new(dir = dir)$get(partition, rec$id)
+  expect_identical(
+    history_json(restored$nodes$n_0001$ui[[1]]),
+    history_json(ui_msg)
+  )
+})

--- a/pkg-r/tests/testthat/test-chat_history_store.R
+++ b/pkg-r/tests/testthat/test-chat_history_store.R
@@ -1013,9 +1013,6 @@ test_that("safe_conv_path() rejects path traversal", {
 })
 
 test_that("history_json() serializes stored messages with classed tool blocks", {
-  # Regression test: as.list() on a classed list retains its class, so
-  # shinychat_block segments used to reach jsonlite::toJSON() classed and
-  # error with "No method asJSON S3 class: shinychat_block".
   tool_result <- ellmer::ContentToolResult(
     request = ellmer::ContentToolRequest(
       id = "t1",


### PR DESCRIPTION
## Problem

In a Shiny app with chat history enabled (the default in `chat_server()`), any conversation where the assistant calls a tool silently fails to persist. The user sees a "Could not save conversation" notification, and when they reload the app, everything after the tool call is gone.

For example, in a weather app where the model calls a `get_weather()` tool:

1. User asks "What's the weather in Tokyo?" — saved fine.
2. Assistant calls the tool and answers — the answer renders in the chat, but the save fails.
3. On reload, the conversation has lost step 2.

The same applies to any `chat_append()` content that produces HTML (tags, htmlwidgets, `HTML()`).

## Cause

Tool cards and HTML blocks are S3-classed lists (`shinychat_block`). When building the record to persist, the code tried to strip the class with `as.list()`, but `as.list()` on a classed list keeps the class. The history store's plain `jsonlite::toJSON()` has no serializer for that class and errors. (The live chat survives only because Shiny's own serializer passes `force = TRUE`.)

## Fix

Pass `force = TRUE` to `jsonlite::toJSON()` in `history_json()` — the same escape hatch Shiny's serializer uses — so classed values are unclassed before serialization, no matter how deeply nested.

## Verification

New regression tests build real tool cards via `contents_shinychat()` and HTML blocks via `new_html_block()` and round-trip them through `history_json()` and `FileConversationStore`. They fail with `No method asJSON S3 class: shinychat_block` before the fix and pass after. Full suite: 2036 pass / 0 fail / 6 skip.
