### PR TITLE
fix(r): don't report successful responses as failed when history saving fails

### DIFF
--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -1029,15 +1029,6 @@ chat_enable_history <- function(
     controller$notify_settled(!is.null(controller$record))
   })
 
-  history_notify_error <- function(prefix, e) {
-    shiny::showNotification(
-      paste0(prefix, ": ", sanitized_error_message(e)),
-      type = "error",
-      duration = NULL
-    )
-    rlang::warn(prefix, parent = e)
-  }
-
   select_effect <- shiny::observeEvent(
     session$input[[paste0(id, "_history_select")]],
     label = "history_select",
@@ -1180,6 +1171,15 @@ chat_enable_history <- function(
   invisible(cancel)
 }
 
+history_notify_error <- function(prefix, e) {
+  shiny::showNotification(
+    paste0(prefix, ": ", sanitized_error_message(e)),
+    type = "error",
+    duration = NULL
+  )
+  rlang::warn(prefix, parent = e)
+}
+
 chat_history_on_response <- function(
   id,
   stream_promise,
@@ -1193,18 +1193,22 @@ chat_history_on_response <- function(
     return(stream_promise)
   }
 
-  result <- promises::then(stream_promise, function(value) {
+  promises::then(stream_promise, function(value) {
     if (!controller$is_replaying) {
-      controller$on_response(get_turns_recorded(controller$get_client()))
+      # A persistence failure must not fail an otherwise-successful
+      # response: notify and let the original value through. Scoping the
+      # catch to the save also keeps genuine stream errors from raising a
+      # spurious "Could not save conversation" notification. Mirrors
+      # Python's `_save_on_response` effect.
+      tryCatch(
+        controller$on_response(get_turns_recorded(controller$get_client())),
+        error = function(e) {
+          history_notify_error("Could not save conversation", e)
+        }
+      )
     }
     value
   })
-
-  promises::catch(result, function(e) {
-    history_notify_error("Could not save conversation", e)
-  })
-
-  result
 }
 
 call_on_save <- function(fn, values) {

--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -1195,11 +1195,6 @@ chat_history_on_response <- function(
 
   promises::then(stream_promise, function(value) {
     if (!controller$is_replaying) {
-      # A persistence failure must not fail an otherwise-successful
-      # response: notify and let the original value through. Scoping the
-      # catch to the save also keeps genuine stream errors from raising a
-      # spurious "Could not save conversation" notification. Mirrors
-      # Python's `_save_on_response` effect.
       tryCatch(
         controller$on_response(get_turns_recorded(controller$get_client())),
         error = function(e) {

--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -976,7 +976,7 @@ chat_enable_history <- function(
         target <- tryCatch(
           controller$get_record(controller$partition, restored_id),
           error = function(e) {
-            history_notify_error("Could not load conversation", e)
+            notify_error("Could not load conversation", e)
             NULL
           }
         )
@@ -1009,7 +1009,7 @@ chat_enable_history <- function(
       target <- tryCatch(
         controller$get_record(controller$partition, current_id),
         error = function(e) {
-          history_notify_error("Could not load conversation", e)
+          notify_error("Could not load conversation", e)
           NULL
         }
       )
@@ -1040,7 +1040,7 @@ chat_enable_history <- function(
       tryCatch(
         controller$switch_to(as.character(payload$id)[[1L]]),
         error = function(e) {
-          history_notify_error("Could not open conversation", e)
+          notify_error("Could not open conversation", e)
         }
       )
     }
@@ -1056,7 +1056,7 @@ chat_enable_history <- function(
       tryCatch(
         controller$new_chat(),
         error = function(e) {
-          history_notify_error("Could not start a new chat", e)
+          notify_error("Could not start a new chat", e)
         }
       )
     }
@@ -1076,7 +1076,7 @@ chat_enable_history <- function(
           as.character(payload$title)[[1L]]
         ),
         error = function(e) {
-          history_notify_error("Could not rename conversation", e)
+          notify_error("Could not rename conversation", e)
         }
       )
     }
@@ -1093,7 +1093,7 @@ chat_enable_history <- function(
       tryCatch(
         controller$delete(as.character(payload$id)[[1L]]),
         error = function(e) {
-          history_notify_error("Could not delete conversation", e)
+          notify_error("Could not delete conversation", e)
         }
       )
     }
@@ -1114,7 +1114,7 @@ chat_enable_history <- function(
           payload$attachments
         ),
         error = function(e) {
-          history_notify_error("Could not edit message", e)
+          notify_error("Could not edit message", e)
         }
       )
     }
@@ -1134,7 +1134,7 @@ chat_enable_history <- function(
           as.character(payload$direction)[[1L]]
         ),
         error = function(e) {
-          history_notify_error("Could not navigate messages", e)
+          notify_error("Could not navigate messages", e)
         }
       )
     }
@@ -1171,15 +1171,6 @@ chat_enable_history <- function(
   invisible(cancel)
 }
 
-history_notify_error <- function(prefix, e) {
-  shiny::showNotification(
-    paste0(prefix, ": ", sanitized_error_message(e)),
-    type = "error",
-    duration = NULL
-  )
-  rlang::warn(prefix, parent = e)
-}
-
 chat_history_on_response <- function(
   id,
   stream_promise,
@@ -1198,7 +1189,7 @@ chat_history_on_response <- function(
       tryCatch(
         controller$on_response(get_turns_recorded(controller$get_client())),
         error = function(e) {
-          history_notify_error("Could not save conversation", e)
+          notify_error("Could not save conversation", e)
         }
       )
     }

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -1558,7 +1558,6 @@ test_that("chat_history_on_response() resolves with the stream value when saving
   )
   set_session_chat_bookmark_info(session, "chat.history-controller", controller)
 
-  # A persistence failure must not fail an otherwise-successful response.
   p <- chat_history_on_response(
     "chat",
     promises::promise_resolve("stream-value"),

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -1512,3 +1512,86 @@ test_that("node with neither usable UI nor turns falls back to text-only", {
     ""
   )
 })
+
+test_that("chat_history_on_response() saves the response and passes through its value", {
+  session <- shiny::MockShinySession$new()
+  notified <- NULL
+  testthat::local_mocked_bindings(
+    history_notify_error = function(prefix, e) notified <<- prefix
+  )
+
+  saved <- NULL
+  fake_client <- list(get_turns = function() list(), get_tools = function() {
+    list()
+  })
+  controller <- list(
+    is_replaying = FALSE,
+    get_client = function() fake_client,
+    on_response = function(turns) saved <<- turns
+  )
+  set_session_chat_bookmark_info(session, "chat.history-controller", controller)
+
+  p <- chat_history_on_response(
+    "chat",
+    promises::promise_resolve("stream-value"),
+    session = session
+  )
+  expect_equal(sync(p), "stream-value")
+  expect_equal(saved, list())
+  expect_null(notified)
+})
+
+test_that("chat_history_on_response() resolves with the stream value when saving fails", {
+  session <- shiny::MockShinySession$new()
+  notified <- NULL
+  testthat::local_mocked_bindings(
+    history_notify_error = function(prefix, e) notified <<- prefix
+  )
+
+  fake_client <- list(get_turns = function() list(), get_tools = function() {
+    list()
+  })
+  controller <- list(
+    is_replaying = FALSE,
+    get_client = function() fake_client,
+    on_response = function(turns) stop("simulated save failure")
+  )
+  set_session_chat_bookmark_info(session, "chat.history-controller", controller)
+
+  # A persistence failure must not fail an otherwise-successful response.
+  p <- chat_history_on_response(
+    "chat",
+    promises::promise_resolve("stream-value"),
+    session = session
+  )
+  expect_equal(sync(p), "stream-value")
+  expect_equal(notified, "Could not save conversation")
+})
+
+test_that("chat_history_on_response() propagates stream errors without saving or notifying", {
+  session <- shiny::MockShinySession$new()
+  notified <- NULL
+  testthat::local_mocked_bindings(
+    history_notify_error = function(prefix, e) notified <<- prefix
+  )
+
+  saved <- FALSE
+  fake_client <- list(get_turns = function() list(), get_tools = function() {
+    list()
+  })
+  controller <- list(
+    is_replaying = FALSE,
+    get_client = function() fake_client,
+    on_response = function(turns) saved <<- TRUE
+  )
+  set_session_chat_bookmark_info(session, "chat.history-controller", controller)
+
+  p <- chat_history_on_response(
+    "chat",
+    promises::promise_reject("model exploded"),
+    session = session
+  )
+  expect_error(sync(p), "model exploded")
+  expect_false(saved)
+  expect_null(notified)
+})

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -1517,7 +1517,7 @@ test_that("chat_history_on_response() saves the response and passes through its 
   session <- shiny::MockShinySession$new()
   notified <- NULL
   testthat::local_mocked_bindings(
-    history_notify_error = function(prefix, e) notified <<- prefix
+    notify_error = function(prefix, e) notified <<- prefix
   )
 
   saved <- NULL
@@ -1545,7 +1545,7 @@ test_that("chat_history_on_response() resolves with the stream value when saving
   session <- shiny::MockShinySession$new()
   notified <- NULL
   testthat::local_mocked_bindings(
-    history_notify_error = function(prefix, e) notified <<- prefix
+    notify_error = function(prefix, e) notified <<- prefix
   )
 
   fake_client <- list(get_turns = function() list(), get_tools = function() {
@@ -1571,7 +1571,7 @@ test_that("chat_history_on_response() propagates stream errors without saving or
   session <- shiny::MockShinySession$new()
   notified <- NULL
   testthat::local_mocked_bindings(
-    history_notify_error = function(prefix, e) notified <<- prefix
+    notify_error = function(prefix, e) notified <<- prefix
   )
 
   saved <- FALSE


### PR DESCRIPTION
## Problem

If saving the conversation history fails for any reason — a disk error, a permissions problem, a serialization bug — the app reports the assistant's *response* as failed, even though it rendered perfectly. The user watches a complete answer stream in, then sees an error message appended below it as if the model call had failed, and anything inspecting the chat's `status`/`last_error` sees a failure.

A secondary bug made this worse: the notification meant to explain the save failure ("Could not save conversation") itself crashed, because `history_notify_error()` was defined inside another function and wasn't visible where it was called — surfacing as an unhandled promise error instead.

## Fix

History saving is now isolated from the response: if the save fails, the user gets the "Could not save conversation" notification and the response still counts as successful. This matches the Python package, where history saving is a side effect that can never fail the response.

As a side benefit, a genuine model or stream error no longer triggers the misleading "Could not save conversation" notification on top of the real error.

## Verification

Three new tests cover: (1) a successful save passes the response through, (2) a save failure still reports the response as successful and notifies, (3) genuine stream errors still fail, without a spurious save notification. All fail before the fix and pass after. Full suite: 2038 pass / 0 fail / 6 skip.
