### PR TITLE
fix(r): read namespaced history stamp on bookmark restore in modules

### DIFF
--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -971,7 +971,14 @@ chat_enable_history <- function(
     # Priority 1: restore from a Shiny bookmark context (any mode).
     rc <- session$restoreContext
     if (!is.null(rc) && isTRUE(rc$active)) {
-      restored_id <- rc$values[[stamp_key]]
+      # The stamp is written via the (possibly module) session's onBookmark,
+      # which namespaces value keys with session$ns(). `session$restoreContext`
+      # is NOT namespaced by the module session proxy -- it is the root
+      # restore context -- so the read must apply the namespace explicitly.
+      # The bare-key fallback covers sessions whose onBookmark does not
+      # namespace values (e.g. MockShinySession).
+      restored_id <- rc$values[[session$ns(stamp_key)]] %||%
+        rc$values[[stamp_key]]
       if (!is.null(restored_id) && nzchar(restored_id)) {
         target <- tryCatch(
           controller$get_record(controller$partition, restored_id),

--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -971,12 +971,9 @@ chat_enable_history <- function(
     # Priority 1: restore from a Shiny bookmark context (any mode).
     rc <- session$restoreContext
     if (!is.null(rc) && isTRUE(rc$active)) {
-      # The stamp is written via the (possibly module) session's onBookmark,
-      # which namespaces value keys with session$ns(). `session$restoreContext`
-      # is NOT namespaced by the module session proxy -- it is the root
-      # restore context -- so the read must apply the namespace explicitly.
-      # The bare-key fallback covers sessions whose onBookmark does not
-      # namespace values (e.g. MockShinySession).
+      # Module onBookmark values are namespaced, but restoreContext is the
+      # root context, so apply session$ns(). The bare-key fallback covers
+      # sessions that don't namespace onBookmark values (MockShinySession).
       restored_id <- rc$values[[session$ns(stamp_key)]] %||%
         rc$values[[stamp_key]]
       if (!is.null(restored_id) && nzchar(restored_id)) {

--- a/pkg-r/tests/testthat/test-chat_history_integration.R
+++ b/pkg-r/tests/testthat/test-chat_history_integration.R
@@ -654,6 +654,66 @@ test_that("bookmark startup restores history state after activating conversation
   })
 })
 
+test_that("bookmark startup restores history state in a module (namespaced stamp)", {
+  skip_if_not_installed("ellmer")
+
+  old_bookmark_store <- shiny::getShinyOption("bookmarkStore", NULL)
+  withr::defer(shiny::shinyOptions(bookmarkStore = old_bookmark_store))
+
+  client <- mock_chat_client()
+  root_session <- shiny::MockShinySession$new()
+  mod_session <- root_session$makeScope("mod")
+  store <- InMemoryConversationStore$new()
+  record <- new_conversation_record("Prior conversation")
+  record$values <- list(marker = "from-history")
+  store$put(
+    conversation_partition(mod_session$ns("chat"), "test-user"),
+    record
+  )
+  # Module onBookmark values are namespaced with session$ns() on write, and
+  # the restore context is the root context, so the stamp key arrives
+  # namespaced.
+  root_session$restoreContext <- list(
+    active = TRUE,
+    values = stats::setNames(
+      list(record$id),
+      mod_session$ns("chat_history_conversation_id")
+    )
+  )
+
+  restored_marker <- NULL
+  observed_id <- NULL
+  server <- function(input, output, session) {
+    shiny::shinyOptions(bookmarkStore = "server")
+    chat_enable_history(
+      "chat",
+      client,
+      on_restore = function(values) {
+        restored_marker <<- values$marker
+        ctrl <- get_session_chat_bookmark_info(
+          mod_session,
+          "chat.history-controller"
+        )
+        observed_id <<- ctrl$record$id
+      },
+      options = history_options(
+        restore_mode = "bookmark",
+        store = store,
+        scope = "test-user",
+        title = NULL
+      ),
+      session = mod_session
+    )
+  }
+
+  shiny::testServer(server, session = root_session, {
+    session$flushReact()
+
+    expect_identical(restored_marker, "from-history")
+    expect_identical(observed_id, record$id)
+  })
+})
+
 test_that("set_client() does not re-render the UI or double-fire on_restore (regression)", {
   # Regression: chat_enable_history() was re-run from scratch on every
   # set_client() swap, spinning up a fresh controller/init effect with no


### PR DESCRIPTION
## Summary
When a chat with history lives in a Shiny module, returning to a previous conversation in `restore_mode = "bookmark"` showed only the greeting — the conversation was never replayed. The conversation-ID stamp is written via the session's `onBookmark`, which namespaces value keys in modules (`makeScope` namespaces module bookmark values). The restore read `session$restoreContext$values` with the bare key, but `session$restoreContext` is the root restore context — module session proxies do not namespace it — so the lookup always missed in modules.

## Fix
Read the stamp with `session$ns()` applied, falling back to the bare key for sessions whose `onBookmark` does not namespace values (e.g. `MockShinySession`).

## Verification
In a module-based app with bookmark-mode history (e.g. `querychat::querychat_app(penguins, greeting = "hello")`), chat, wait for the `?_state_id_=` URL, reload it: the conversation (including tool cards) is now restored. `devtools::test(filter = "chat_history")` passes (474 tests).