### PR TITLE
ci: split py-check into parallel jobs for faster feedback

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -38,7 +38,7 @@ jobs:
     if: github.event_name != 'release' || startsWith(github.ref, 'refs/tags/r/v')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.9.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -46,6 +46,10 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
+          # Distinct cache key per job: every job syncs a different environment
+          # (and the py-test matrix syncs per Python version), so a shared key
+          # races on save and matrix legs restore a partial cache.
+          cache-suffix: py-format
 
       - name: 📐 Check formatting
         run: make py-check-format
@@ -62,6 +66,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
+          cache-suffix: py-types
 
       - name: 🐍 Set up Python 3.10
         run: uv python install 3.10
@@ -94,6 +99,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
+          cache-suffix: py-test-${{ matrix.python-version }}
 
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -119,6 +125,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
+          cache-suffix: py-playwright
 
       - name: 🐍 Set up Python ${{ env.PLAYWRIGHT_PYTHON_VERSION }}
         run: uv python install ${{ env.PLAYWRIGHT_PYTHON_VERSION }}

--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -37,13 +37,13 @@ jobs:
   py-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v6.1.0
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 
@@ -53,13 +53,13 @@ jobs:
   py-types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v6.1.0
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 
@@ -85,13 +85,13 @@ jobs:
           - "3.14"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v6.1.0
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 
@@ -110,13 +110,13 @@ jobs:
   py-playwright:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v6.1.0
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 
@@ -131,7 +131,7 @@ jobs:
         run: echo "version=$(uv run playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
 
       - name: 🎭 Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}

--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -1,3 +1,11 @@
+# Checks for pkg-py, split into independent jobs so fast failures (formatting,
+# types) surface while the slower test jobs are still running.
+#
+# Every job uses a full-history checkout: hatch-vcs needs the latest py/v* tag
+# to compute a real workspace version (e.g. 0.3.2.devN+gSHA). The fallback
+# (0.1.dev1+gSHA) sorts before 0.1.0 (PEP 440), so it can't satisfy shiny>=1.5's
+# transitive `shinychat>=0.1.0` and uv silently downgrades shiny to 1.4.0, which
+# lacks the htmltools-0.7.0 Tagifiable fixes.
 name: py-check.yaml
 
 on:
@@ -16,10 +24,54 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same PR; runs on main are never cancelled.
+concurrency:
+  group: py-check-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
-  UV_VERSION: "0.9.x"
+  UV_VERSION: "0.12.10"
+  PLAYWRIGHT_PYTHON_VERSION: "3.14"
 
 jobs:
+  py-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v6.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: 📐 Check formatting
+        run: make py-check-format
+
+  py-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v6.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: 🐍 Set up Python 3.10
+        run: uv python install 3.10
+
+      - name: 📦 Install the project
+        run: uv sync --python 3.10 --all-extras --all-groups
+
+      - name: 📝 Check types
+        run: make py-check-types
+
   py-test:
     runs-on: ubuntu-latest
     strategy:
@@ -35,13 +87,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need full history + tags so hatch-vcs computes a real
-          # workspace version (e.g. 0.3.2.devN+gSHA, derived from the
-          # latest py/v* tag) instead of the fallback 0.1.dev1+gSHA.
-          # The fallback sorts before 0.1.0 (PEP 440), so it can't
-          # satisfy shiny>=1.5's transitive `shinychat>=0.1.0` and
-          # uv silently downgrades shiny to 1.4.0, which lacks the
-          # htmltools-0.7.0 Tagifiable fixes.
           fetch-depth: 0
           fetch-tags: true
 
@@ -59,11 +104,37 @@ jobs:
       - name: 📜 Show uv.lock
         run: cat uv.lock
 
-      - name: 🧪 Check tests
-        run: make py-check-tests
+      - name: 🧪 Check unit tests
+        run: make py-check-unit
 
-      - name: 📝 Check types
-        run: make py-check-types
+  py-playwright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-      - name: 📐 Check formatting
-        run: make py-check-format
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v6.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: 🐍 Set up Python ${{ env.PLAYWRIGHT_PYTHON_VERSION }}
+        run: uv python install ${{ env.PLAYWRIGHT_PYTHON_VERSION }}
+
+      - name: 📦 Install the project
+        run: uv sync --python ${{ env.PLAYWRIGHT_PYTHON_VERSION }} --all-extras --all-groups
+
+      - name: 🎭 Get Playwright version
+        id: playwright-version
+        run: echo "version=$(uv run playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: 🎭 Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+
+      - name: 🎭 Check playwright tests
+        run: make py-check-playwright

--- a/.github/workflows/py-release.yaml
+++ b/.github/workflows/py-release.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
+          cache-suffix: py-release
 
       - name: 🐍 Set up Python ${{ env.PYTHON_VERSION }}
         run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/py-release.yaml
+++ b/.github/workflows/py-release.yaml
@@ -24,10 +24,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 

--- a/.github/workflows/py-release.yaml
+++ b/.github/workflows/py-release.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  UV_VERSION: "0.9.x"
+  UV_VERSION: "0.12.10"
   PYTHON_VERSION: 3.13
 
 jobs:

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  UV_VERSION: "0.9.x"
+  UV_VERSION: "0.12.10"
   PYTHON_VERSION: 3.13
   QUARTO_VERSION: 1.7.31
 

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -37,6 +37,9 @@ jobs:
       uses: astral-sh/setup-uv@v10.0.1
       with:
         version: ${{ env.UV_VERSION }}
+        # Distinct cache key so this job can't race (or share keys) with the
+        # concurrent py-check jobs when both workflows trigger on the same PR.
+        cache-suffix: quartodoc
 
     - name: 🐍 Set up Python ${{ env.PYTHON_VERSION }}
       run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0 # full history needed for correct versioning of py pkg
 
@@ -34,7 +34,7 @@ jobs:
         version: ${{ env.QUARTO_VERSION }}
 
     - name: 🚀 Install uv
-      uses: astral-sh/setup-uv@v6.1.0
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: ${{ env.UV_VERSION }}
 
@@ -57,7 +57,7 @@ jobs:
 
     - name: 🚢 Deploy to GitHub pages
       if: github.event_name != 'pull_request'
-      uses: JamesIves/github-pages-deploy-action@v4.5.0
+      uses: JamesIves/github-pages-deploy-action@v4.9.0
       with:
         clean: false
         folder: docs

--- a/.github/workflows/verify-js-built.yaml
+++ b/.github/workflows/verify-js-built.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
           echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: 🟡 Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "${{ steps.nvm.outputs.version }}"
 

--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,25 @@ py-check-tox:  ## [py] Run python checks across versions with tox
 	uv run tox run-parallel
 
 .PHONY: py-check-tests
-py-check-tests:  ## [py] Run python tests (FILTER=... for pytest -k selection)
+py-check-tests:  py-check-unit py-check-playwright ## [py] Run all python tests (FILTER=... for pytest -k selection)
+
+.PHONY: py-check-unit
+py-check-unit:  ## [py] Run python unit tests (FILTER=... for pytest -k selection)
 	@echo ""
-	@echo "🧪 Running tests with pytest"
-	uv run playwright install
-	uv run pytest pkg-py/tests/playwright/ $(if $(FILTER),-k "$(FILTER)")
+	@echo "🧪 Running unit tests with pytest"
 	uv run pytest --ignore=pkg-py/tests/playwright/ $(if $(FILTER),-k "$(FILTER)")
+
+.PHONY: py-check-playwright
+py-check-playwright:  ## [py] Run playwright tests (FILTER=... for pytest -k selection)
+	@echo ""
+	@echo "🎭 Running playwright tests"
+	uv run playwright install chromium
+	uv run pytest pkg-py/tests/playwright/ $(if $(FILTER),-k "$(FILTER)")
+
+.PHONY: py-check-playwright-debug
+py-check-playwright-debug:  ## [py] Run playwright tests headed with slowmo, traces, and video (FILTER=... for pytest -k selection)
+	uv run playwright install chromium
+	uv run pytest pkg-py/tests/playwright/ --headed --slowmo=250 --tracing=on --video=on $(if $(FILTER),-k "$(FILTER)")
 
 .PHONY: py-check-types
 py-check-types:  ## [py] Run python type checks

--- a/pkg-py/tests/playwright/playwright-pytest.ini
+++ b/pkg-py/tests/playwright/playwright-pytest.ini
@@ -9,8 +9,7 @@ asyncio_mode=strict
 # --tracing=retain-on-failure: playwright saves trace of any failed test
 # --video=on: Always save playwright recording for every test
 # --tracing=on: Always save playwright trace for every test
-# -vv: Extra extra verbose output
-# # --headed: Headed browser testing
-# # -r P: Show extra test summary info: (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. (w)arnings...
+# -vvv: Extra extra verbose output
 # --maxfail=1: Stop after 1 failure has occurred
-addopts = --strict-markers --durations=6 --durations-min=5.0 --browser chromium --numprocesses auto -vvv --maxfail=1 --headed --tracing=on --slowmo=250
+# Debugging (headed, slowmo, always-on traces/video): make py-check-playwright-debug
+addopts = --strict-markers --durations=6 --durations-min=5.0 --browser chromium --numprocesses auto -vvv --maxfail=1 --tracing=retain-on-failure --video=retain-on-failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ version-file = "pkg-py/src/shinychat/__version.py"
 [tool.pyright]
 include = ["pkg-py"]
 exclude = ["pkg-py/_dev"]
+pythonVersion = "3.10"
 
 [tool.pytest.ini_options]
 testpaths = ["pkg-py/tests"]


### PR DESCRIPTION
No linked issues.

## Summary

py-check.yaml was a single job that did everything serially on a 5-version matrix, so each leg ran ruff and pyright five times and the playwright suite five times behind a browser download. A run took about 7 minutes.

The workflow now starts four independent jobs at once, and none of them gate the others:

- py-format: ruff, once
- py-types: pyright on 3.10
- py-test: unit tests on the 3.10 through 3.14 matrix, no browser download needed
- py-playwright: the playwright suite on 3.14, chromium cached between runs

A formatting or type failure now shows up in about a minute while the test jobs keep running, and the wall clock is the playwright job instead of the sum of everything. Superseded runs on a PR cancel as soon as the next push arrives.

pyright gets pythonVersion = "3.10" in pyproject.toml. The analysis target now lives in config instead of depending on which interpreter runs the check, and 3.10 is the direction that catches bugs, since it flags stdlib APIs added after 3.10.

The playwright pytest config had leftover debug flags in addopts (--headed, --slowmo=250, --tracing=on), which the CI timing data showed as most of the cost. The suite runs headless again and records traces and video only on failure. For debugging, the new make py-check-playwright-debug target runs headed with slowmo and always-on traces and video. The browser install narrows to chromium, the only browser the suite uses.

Also pins uv at 0.12.10 in py-check, py-release, and quartodoc, which were all on 0.9.x.

A follow-up commit bumps the GitHub Actions across all workflows to their current versions: checkout to v7, setup-uv to v10.0.1 (py-release was still on v3), cache to v6, setup-node to v7, and github-pages-deploy-action to v4.9.0. The newer versions run on node24, which clears the node20 deprecation warnings that appeared on every run. r-lib/actions@v2, quarto-actions@v2, and shiny-workflows@v1 stay as they are the latest, and the pypa publish action keeps its recommended release/v1 branch pin.


One more refinement on the caches: setup-uv's default cache key is the lockfile hash, so all seven concurrent jobs raced to save the same key and every job but the winner logged a "Failed to save" annotation. The winner's cache was also partial, since each Python version needs its own cp-specific wheels and only one job's uploads survived. Each job now sets cache-suffix, so every environment gets its own complete cache with no save races, and quartodoc and py-release are isolated too. Runs are cold once per lockfile change and warm after that.
