### PR TITLE
Add new_chat for conversation history

### DIFF
--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -1894,7 +1894,13 @@ class Chat:
 
     async def clear_messages(self, *, greeting: bool = False):
         """
-        Clear all chat messages.
+        Clear all rendered chat messages.
+
+        This is a UI-level primitive. It does not reset the underlying
+        client's turns or the conversation-history controller. When a chat
+        was created with a client and conversation history is enabled, use
+        ``await chat.client.clear()`` for a coordinated new-conversation
+        reset.
 
         Parameters
         ----------

--- a/pkg-py/src/shinychat/_chat.py
+++ b/pkg-py/src/shinychat/_chat.py
@@ -1899,7 +1899,7 @@ class Chat:
         This is a UI-level primitive. It does not reset the underlying
         client's turns or the conversation-history controller. When a chat
         was created with a client and conversation history is enabled, use
-        ``await chat.client.clear()`` for a coordinated new-conversation
+        ``await chat.client.new_chat()`` for a coordinated new-conversation
         reset.
 
         Parameters

--- a/pkg-py/src/shinychat/_chat_client.py
+++ b/pkg-py/src/shinychat/_chat_client.py
@@ -100,17 +100,11 @@ class ChatClient:
         """
         Clear the chat and optionally reset the client's turn history.
 
-        When conversation history is enabled, the default operation starts a
-        new conversation through the history controller. The current record
-        is saved before the client turns, rendered messages, active
-        conversation ID, and history drawer state are reset. In that mode,
-        ``messages`` and the non-default ``client_history`` modes are not
-        supported because they can make the rendered chat, client turns, and
-        persisted conversation disagree.
-
-        When conversation history is disabled, this method retains its
-        existing behavior and ``client_history`` controls only the underlying
-        client's turns.
+        This is a lower-level operation for chats without conversation
+        history. ``client_history`` controls only the underlying client's
+        turns. When conversation history is enabled, use :meth:`new_chat`
+        instead so the rendered chat, client turns, and persisted conversation
+        remain synchronized.
 
         Parameters
         ----------
@@ -119,14 +113,11 @@ class ChatClient:
             ``client_history`` is ``"set"`` or ``"append"``, and not allowed
             with ``"clear"`` or ``"keep"``.
         greeting
-            Passed to :meth:`~shinychat.Chat.clear_messages`. With history
-            enabled, ``True`` also causes the configured greeting to be
-            resolved for the new conversation.
+            Passed to :meth:`~shinychat.Chat.clear_messages`.
         client_history
             How to handle the client's turn history:
 
-            * ``"clear"`` (default): removes all turns from the client. With
-              history enabled, this starts a new saved-history conversation.
+            * ``"clear"`` (default): removes all turns from the client.
             * ``"set"``: sets the client's turns to ``messages``.  Requires
               ``messages`` to be provided.
             * ``"append"``: appends ``messages`` to the client's existing turns.
@@ -152,17 +143,10 @@ class ChatClient:
             getattr(self._chat, "history", None), "_controller", None
         )
         if history_controller is not None:
-            if messages is not None:
-                raise ValueError(
-                    "`messages` cannot be supplied when conversation history "
-                    "is enabled; use `chat.client.clear()` to start a new "
-                    "conversation."
-                )
-            if client_history != "clear":
-                raise ValueError(
-                    '`client_history` must be "clear" when conversation '
-                    "history is enabled."
-                )
+            raise ValueError(
+                "Can't clear a chat with conversation history enabled; use "
+                "`await chat.client.new_chat()` to start a new conversation."
+            )
         if client_history in ("set", "append") and messages is None:
             raise ValueError(
                 f"`messages` must be provided when `client_history='{client_history}'`."
@@ -181,10 +165,6 @@ class ChatClient:
                 sanitize=False,
             )
 
-        if history_controller is not None:
-            await history_controller.new_chat(greeting=greeting)
-            return
-
         await self._chat.clear_messages(greeting=greeting)
 
         if messages is not None:
@@ -202,6 +182,51 @@ class ChatClient:
             turns = self._client.get_turns() + messages_to_turns(messages)
             self._client.set_turns(turns)
         # "keep" → do nothing
+
+    async def new_chat(self, *, greeting: bool = False) -> None:
+        """
+        Save the current conversation and start a new one.
+
+        This method is available only when conversation history is enabled.
+        It saves the current record, clears the client turns and rendered
+        messages, resets the active conversation ID, and updates the history
+        drawer.
+
+        Parameters
+        ----------
+        greeting
+            Passed to :meth:`~shinychat.Chat.clear_messages`. When ``True``,
+            also clears the greeting and resolves the configured greeting for
+            the new conversation.
+
+        Raises
+        ------
+        ValueError
+            If conversation history is not enabled.
+        shiny.types.NotifyException
+            If an assistant response is currently streaming. To avoid this
+            error, guard the call by checking
+            ``chat.latest_message_stream.status() != "running"`` before
+            calling :meth:`new_chat`.
+        """
+        history_controller = getattr(
+            getattr(self._chat, "history", None), "_controller", None
+        )
+        if history_controller is None:
+            raise ValueError(
+                "Can't start a new chat without conversation history enabled; "
+                "use `await chat.client.clear()` instead."
+            )
+        if self._chat.latest_message_stream.status() == "running":
+            from shiny.types import NotifyException
+
+            raise NotifyException(
+                "Can't start a new chat while a response is still being "
+                "generated. Please wait for it to finish or stop it first.",
+                sanitize=False,
+            )
+
+        await history_controller.new_chat(greeting=greeting)
 
 
 def messages_to_turns(

--- a/pkg-py/src/shinychat/_chat_client.py
+++ b/pkg-py/src/shinychat/_chat_client.py
@@ -139,9 +139,7 @@ class ChatClient:
                 f"`client_history={client_history!r}` is not valid. Expected "
                 'one of "clear", "set", "append", or "keep".'
             )
-        history_controller = getattr(
-            getattr(self._chat, "history", None), "_controller", None
-        )
+        history_controller = self._chat.history._controller
         if history_controller is not None:
             raise ValueError(
                 "Can't clear a chat with conversation history enabled; use "
@@ -209,9 +207,7 @@ class ChatClient:
             ``chat.latest_message_stream.status() != "running"`` before
             calling :meth:`new_chat`.
         """
-        history_controller = getattr(
-            getattr(self._chat, "history", None), "_controller", None
-        )
+        history_controller = self._chat.history._controller
         if history_controller is None:
             raise ValueError(
                 "Can't start a new chat without conversation history enabled; "

--- a/pkg-py/src/shinychat/_chat_client.py
+++ b/pkg-py/src/shinychat/_chat_client.py
@@ -98,7 +98,19 @@ class ChatClient:
         client_history: Literal["clear", "set", "append", "keep"] = "clear",
     ) -> None:
         """
-        Clear chat messages and optionally reset the client's turn history.
+        Clear the chat and optionally reset the client's turn history.
+
+        When conversation history is enabled, the default operation starts a
+        new conversation through the history controller. The current record
+        is saved before the client turns, rendered messages, active
+        conversation ID, and history drawer state are reset. In that mode,
+        ``messages`` and the non-default ``client_history`` modes are not
+        supported because they can make the rendered chat, client turns, and
+        persisted conversation disagree.
+
+        When conversation history is disabled, this method retains its
+        existing behavior and ``client_history`` controls only the underlying
+        client's turns.
 
         Parameters
         ----------
@@ -107,11 +119,14 @@ class ChatClient:
             ``client_history`` is ``"set"`` or ``"append"``, and not allowed
             with ``"clear"`` or ``"keep"``.
         greeting
-            Passed to :meth:`~shinychat.Chat.clear_messages`.
+            Passed to :meth:`~shinychat.Chat.clear_messages`. With history
+            enabled, ``True`` also causes the configured greeting to be
+            resolved for the new conversation.
         client_history
             How to handle the client's turn history:
 
-            * ``"clear"`` (default): removes all turns from the client.
+            * ``"clear"`` (default): removes all turns from the client. With
+              history enabled, this starts a new saved-history conversation.
             * ``"set"``: sets the client's turns to ``messages``.  Requires
               ``messages`` to be provided.
             * ``"append"``: appends ``messages`` to the client's existing turns.
@@ -133,6 +148,21 @@ class ChatClient:
                 f"`client_history={client_history!r}` is not valid. Expected "
                 'one of "clear", "set", "append", or "keep".'
             )
+        history_controller = getattr(
+            getattr(self._chat, "history", None), "_controller", None
+        )
+        if history_controller is not None:
+            if messages is not None:
+                raise ValueError(
+                    "`messages` cannot be supplied when conversation history "
+                    "is enabled; use `chat.client.clear()` to start a new "
+                    "conversation."
+                )
+            if client_history != "clear":
+                raise ValueError(
+                    '`client_history` must be "clear" when conversation '
+                    "history is enabled."
+                )
         if client_history in ("set", "append") and messages is None:
             raise ValueError(
                 f"`messages` must be provided when `client_history='{client_history}'`."
@@ -150,6 +180,10 @@ class ChatClient:
                 "generated. Please wait for it to finish or stop it first.",
                 sanitize=False,
             )
+
+        if history_controller is not None:
+            await history_controller.new_chat(greeting=greeting)
+            return
 
         await self._chat.clear_messages(greeting=greeting)
 

--- a/pkg-py/src/shinychat/_history.py
+++ b/pkg-py/src/shinychat/_history.py
@@ -634,10 +634,19 @@ class HistoryController:
         await self._send_sibling_metadata()
         await self.send_history_update()
 
-    async def new_chat(self) -> None:
+    async def new_chat(self, *, greeting: bool = False) -> None:
+        """
+        Start a new conversation.
+
+        The current conversation is saved before the client turns, rendered
+        messages, active ID, and history drawer state are reset. ``greeting``
+        is forwarded to :meth:`Chat.clear_messages`; when ``True``, the
+        greeting is cleared and the configured greeting is resolved again
+        after the new-chat transition settles.
+        """
         await self.save_current()
         self.adapter.set_turns_json([])
-        await self.chat.clear_messages()
+        await self.chat.clear_messages(greeting=greeting)
         self.ui_offset = 0
         # Announce the cleared state even when the active ID is already None:
         # in URL/bookmark restore modes the browser may still carry a stale

--- a/pkg-py/tests/pytest/test_chat_auto.py
+++ b/pkg-py/tests/pytest/test_chat_auto.py
@@ -96,11 +96,16 @@ class _MockStreamTask:
         return self._status
 
 
+class _StubHistory:
+    _controller: object | None = None
+
+
 class _StubChat:
     def __init__(self, *, stream_status: str = "initial") -> None:
         self.latest_message_stream = _MockStreamTask(stream_status)
         self.clear_calls: list[bool] = []
         self.appended_messages: list[ChatMessageDict] = []
+        self.history = _StubHistory()
 
     async def clear_messages(self, *, greeting: bool = False) -> None:
         self.clear_calls.append(greeting)

--- a/pkg-py/tests/pytest/test_chat_clear_history.py
+++ b/pkg-py/tests/pytest/test_chat_clear_history.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from shiny.types import NotifyException
 from shinychat._chat_client import ChatClient, messages_to_turns
 from shinychat._chat_types import ChatMessageDict
 from shinychat._history import HistoryController
@@ -15,8 +16,11 @@ from shinychat._history_store import (
 
 
 class _Stream:
+    def __init__(self, state: str = "initial") -> None:
+        self.state = state
+
     def status(self) -> str:
-        return "initial"
+        return self.state
 
 
 class _TurnClient:
@@ -102,7 +106,7 @@ def _set_exchange(
 
 
 @pytest.mark.anyio
-async def test_history_aware_clear_saves_and_separates_conversations():
+async def test_new_chat_saves_and_separates_conversations():
     client, chat, raw_client, store = await _make_history_chat()
     controller = chat.history._controller
     assert controller is not None
@@ -114,7 +118,7 @@ async def test_history_aware_clear_saves_and_separates_conversations():
     first_id = first.id
     first_snapshot = first.model_dump(mode="json")
 
-    await client.clear(greeting=True)
+    await client.new_chat(greeting=True)
 
     assert chat.clear_calls == [True]
     assert raw_client.get_turns() == []
@@ -141,41 +145,25 @@ async def test_history_aware_clear_saves_and_separates_conversations():
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ("kwargs", "message"),
+    "kwargs",
     [
-        (
-            {"messages": [{"role": "user", "content": "seed"}]},
-            "messages.*conversation history",
-        ),
-        (
-            {
-                "messages": [{"role": "user", "content": "seed"}],
-                "client_history": "set",
-            },
-            "messages.*conversation history",
-        ),
-        (
-            {"client_history": "set"},
-            "client_history.*clear",
-        ),
-        (
-            {"client_history": "append"},
-            "client_history.*clear",
-        ),
-        (
-            {"client_history": "keep"},
-            "client_history.*clear",
-        ),
+        {},
+        {"messages": [{"role": "user", "content": "seed"}]},
+        {
+            "messages": [{"role": "user", "content": "seed"}],
+            "client_history": "set",
+        },
+        {"client_history": "set"},
+        {"client_history": "append"},
+        {"client_history": "keep"},
     ],
 )
-async def test_history_aware_clear_rejects_advanced_modes(
-    kwargs: dict[str, Any], message: str
-):
+async def test_clear_rejects_history_managed_chats(kwargs: dict[str, Any]):
     client, chat, raw_client, _store = await _make_history_chat()
     _set_exchange(raw_client, chat, "question", "answer")
     before_turns = raw_client.get_turns()
 
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(ValueError, match="new_chat"):
         await client.clear(**kwargs)  # type: ignore[arg-type]
 
     assert raw_client.get_turns() == before_turns
@@ -197,3 +185,27 @@ async def test_history_disabled_clear_keeps_legacy_modes():
     assert chat.clear_calls == [True]
     assert chat.messages == [messages[0]]
     assert raw_client.get_turns() == messages_to_turns(messages)
+
+
+@pytest.mark.anyio
+async def test_new_chat_requires_conversation_history():
+    raw_client = _TurnClient()
+    chat = _Chat()
+    client = ChatClient(chat=cast(Any, chat), client=cast(Any, raw_client))
+
+    with pytest.raises(ValueError, match="conversation history"):
+        await client.new_chat()
+
+
+@pytest.mark.anyio
+async def test_new_chat_rejects_an_in_flight_response():
+    client, chat, raw_client, _store = await _make_history_chat()
+    chat.latest_message_stream.state = "running"
+    turns = [{"role": "user", "content": "question"}]
+    raw_client.set_turns(turns)
+
+    with pytest.raises(NotifyException, match="Can't start a new chat while"):
+        await client.new_chat()
+
+    assert raw_client.get_turns() == turns
+    assert chat.clear_calls == []

--- a/pkg-py/tests/pytest/test_chat_clear_history.py
+++ b/pkg-py/tests/pytest/test_chat_clear_history.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from shinychat._chat_client import ChatClient, messages_to_turns
+from shinychat._chat_types import ChatMessageDict
+from shinychat._history import HistoryController
+from shinychat._history_client import TurnsAdapter
+from shinychat._history_store import (
+    ConversationPartition,
+    InMemoryConversationStore,
+)
+
+
+class _Stream:
+    def status(self) -> str:
+        return "initial"
+
+
+class _TurnClient:
+    def __init__(self) -> None:
+        self._turns: list[Any] = []
+
+    def get_turns(self) -> list[Any]:
+        return list(self._turns)
+
+    def set_turns(self, turns: list[Any]) -> None:
+        self._turns = list(turns)
+
+
+class _Chat:
+    def __init__(self) -> None:
+        self.latest_message_stream = _Stream()
+        self.history = SimpleNamespace(_controller=None)
+        self.messages: list[dict[str, Any]] = []
+        self.clear_calls: list[bool] = []
+        self.actions: list[dict[str, Any]] = []
+        self._session = None
+
+    def _messages_for_bookmark(self) -> list[dict[str, Any]]:
+        return self.messages
+
+    async def clear_messages(self, *, greeting: bool = False) -> None:
+        self.clear_calls.append(greeting)
+        self.messages.clear()
+
+    async def append_message(self, message: dict[str, Any]) -> None:
+        self.messages.append(message)
+
+    async def _send_action(self, action: dict[str, Any]) -> None:
+        self.actions.append(action)
+
+
+def _ui_message(role: str, content: str) -> dict[str, Any]:
+    return {
+        "role": role,
+        "segments": [{"content": content, "content_type": "markdown"}],
+    }
+
+
+async def _make_history_chat() -> tuple[
+    ChatClient, _Chat, _TurnClient, InMemoryConversationStore
+]:
+    raw_client = _TurnClient()
+    chat = _Chat()
+    store = InMemoryConversationStore()
+    controller = HistoryController(
+        chat=chat,  # type: ignore[arg-type]
+        adapter=TurnsAdapter(raw_client),
+        store=store,
+        title_fn=None,
+        title_enabled=False,
+        client=raw_client,
+    )
+    controller.partition = ConversationPartition(
+        chat_id="chat", scope="test-scope"
+    )
+    chat.history._controller = controller
+    return (
+        ChatClient(chat=cast(Any, chat), client=cast(Any, raw_client)),
+        chat,
+        raw_client,
+        store,
+    )
+
+
+def _set_exchange(
+    raw_client: _TurnClient, chat: _Chat, question: str, answer: str
+) -> None:
+    raw_client.set_turns(
+        [
+            {"role": "user", "content": question},
+            {"role": "assistant", "content": answer},
+        ]
+    )
+    chat.messages = [
+        _ui_message("user", question),
+        _ui_message("assistant", answer),
+    ]
+
+
+@pytest.mark.anyio
+async def test_history_aware_clear_saves_and_separates_conversations():
+    client, chat, raw_client, store = await _make_history_chat()
+    controller = chat.history._controller
+    assert controller is not None
+
+    _set_exchange(raw_client, chat, "first question", "first answer")
+    await controller.on_response()
+    first = controller.record
+    assert first is not None
+    first_id = first.id
+    first_snapshot = first.model_dump(mode="json")
+
+    await client.clear(greeting=True)
+
+    assert chat.clear_calls == [True]
+    assert raw_client.get_turns() == []
+    assert chat.messages == []
+    assert controller.record is None
+    assert controller._active_id_now() is None
+    assert any(
+        action.get("type") == "history_update"
+        and action.get("active_id") is None
+        for action in chat.actions
+    )
+
+    _set_exchange(raw_client, chat, "second question", "second answer")
+    await controller.on_response()
+    second = controller.record
+    assert second is not None
+    assert second.id != first_id
+    assert first.model_dump(mode="json") == first_snapshot
+
+    saved_first = await store.get(controller.partition, first_id)
+    assert saved_first is not None
+    assert saved_first.model_dump(mode="json") == first_snapshot
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"messages": [{"role": "user", "content": "seed"}]},
+            "messages.*conversation history",
+        ),
+        (
+            {
+                "messages": [{"role": "user", "content": "seed"}],
+                "client_history": "set",
+            },
+            "messages.*conversation history",
+        ),
+        (
+            {"client_history": "set"},
+            "client_history.*clear",
+        ),
+        (
+            {"client_history": "append"},
+            "client_history.*clear",
+        ),
+        (
+            {"client_history": "keep"},
+            "client_history.*clear",
+        ),
+    ],
+)
+async def test_history_aware_clear_rejects_advanced_modes(
+    kwargs: dict[str, Any], message: str
+):
+    client, chat, raw_client, _store = await _make_history_chat()
+    _set_exchange(raw_client, chat, "question", "answer")
+    before_turns = raw_client.get_turns()
+
+    with pytest.raises(ValueError, match=message):
+        await client.clear(**kwargs)  # type: ignore[arg-type]
+
+    assert raw_client.get_turns() == before_turns
+    assert chat.clear_calls == []
+
+
+@pytest.mark.anyio
+async def test_history_disabled_clear_keeps_legacy_modes():
+    raw_client = _TurnClient()
+    chat = _Chat()
+    client = ChatClient(chat=cast(Any, chat), client=cast(Any, raw_client))
+    messages: list[ChatMessageDict] = [{"role": "user", "content": "seed"}]
+    old_messages: list[ChatMessageDict] = [{"role": "user", "content": "old"}]
+    raw_client.set_turns(messages_to_turns(old_messages))
+    chat.messages = [_ui_message("assistant", "old")]
+
+    await client.clear(messages=messages, greeting=True, client_history="set")
+
+    assert chat.clear_calls == [True]
+    assert chat.messages == [messages[0]]
+    assert raw_client.get_turns() == messages_to_turns(messages)

--- a/pkg-py/tests/test_history_controller.py
+++ b/pkg-py/tests/test_history_controller.py
@@ -254,7 +254,7 @@ class _FakeChat:
     async def _send_action(self, action: Any) -> None:
         pass
 
-    async def clear_messages(self) -> None:
+    async def clear_messages(self, *, greeting: bool = False) -> None:
         pass
 
     async def _restore_bookmark_message(self, message_dict: Any) -> None:
@@ -483,7 +483,7 @@ class _ReplayFakeChat(_FakeChat):
     def _messages_for_bookmark(self) -> list[Any]:
         return self.messages
 
-    async def clear_messages(self) -> None:
+    async def clear_messages(self, *, greeting: bool = False) -> None:
         self.messages = []
 
     async def _restore_bookmark_message(self, message_dict: Any) -> None:
@@ -742,7 +742,7 @@ class _NavFakeChat(_FakeChat):
     async def _send_action(self, action: Any) -> None:
         self.actions.append(dict(action))
 
-    async def clear_messages(self) -> None:
+    async def clear_messages(self, *, greeting: bool = False) -> None:
         self.cleared += 1
 
     async def _restore_bookmark_message(self, message_dict: Any) -> None:
@@ -1722,7 +1722,7 @@ class _TrackingChat:
     async def _send_action(self, action: Any) -> None:
         self.actions.append(action)
 
-    async def clear_messages(self) -> None:
+    async def clear_messages(self, *, greeting: bool = False) -> None:
         self.messages_ = []
         self.cleared = True
 

--- a/pkg-r/R/chat.R
+++ b/pkg-r/R/chat.R
@@ -2072,7 +2072,7 @@ rlang::on_load(
 #'
 #' This is a UI-level primitive: it does not clear an ellmer client's turns or
 #' reset conversation history managed by [chat_server()]. For a full reset of a
-#' managed chat, call the `clear()` method on the value returned by
+#' managed chat, call the `new_chat()` method on the value returned by
 #' [chat_server()].
 #'
 #' @param id The ID of the chat element

--- a/pkg-r/R/chat.R
+++ b/pkg-r/R/chat.R
@@ -2070,6 +2070,11 @@ rlang::on_load(
 #' clear the greeting, which re-triggers `greeting_requested` (see the
 #' **Greeting** section in [chat_ui()]).
 #'
+#' This is a UI-level primitive: it does not clear an ellmer client's turns or
+#' reset conversation history managed by [chat_server()]. For a full reset of a
+#' managed chat, call the `clear()` method on the value returned by
+#' [chat_server()].
+#'
 #' @param id The ID of the chat element
 #' @param greeting If `TRUE`, also clears the greeting. When the greeting is
 #'   cleared, `greeting_requested` will fire again (if the chat is visible),

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -96,14 +96,23 @@
 #'     * `append()`: A function to append a new message to the chat UI. Takes
 #'       the same arguments as [chat_append()], except for `id` and `session`,
 #'       which are supplied automatically.
-#'     * `clear()`: A function to start a new chat by saving the current
-#'       conversation, clearing the chat client's turns and the chat UI, and
-#'       resetting the active conversation. When history is enabled, only the
-#'       empty new-chat form is supported: `messages` must be `NULL` and
-#'       `client_history` must be `"clear"`. Set `history = FALSE` to use the
-#'       other clearing modes. `clear(greeting = TRUE)` also clears the
-#'       greeting and requests a new one. `clear()` errors while a response is
-#'       streaming; wait for it to complete or stop it first.
+#'     * `clear()`: A function to clear the chat client turns and the chat UI.
+#'       It optionally takes a list of `messages` used to initialize the chat
+#'       after clearing. `messages` should be a list of messages, where each
+#'       message is a list with `role` and `content` fields. The
+#'       `client_history` argument controls how the chat client's history is
+#'       updated after clearing. It can be one of: `"clear"` the chat history;
+#'       `"set"` the chat history to `messages`; `"append"` `messages` to the
+#'       existing chat history; or `"keep"` the existing chat history.
+#'       `clear()` is unavailable when conversation history is enabled; use
+#'       `new_chat()` instead.
+#'     * `new_chat()`: A function to save the current conversation and start a
+#'       new one by clearing the chat client's turns and chat UI, resetting the
+#'       active conversation, and updating the history drawer. It is available
+#'       only when conversation history is enabled. `new_chat(greeting = TRUE)`
+#'       also clears the greeting and requests a new one. `new_chat()` errors
+#'       while a response is streaming; wait for it to complete or stop it
+#'       first.
 #'     * `set_greeting()`: A function to set, stream, or clear the chat
 #'       greeting. Pass a [chat_greeting()] object, a plain string, or
 #'       `NULL` to clear. Streaming greetings run inside an
@@ -896,28 +905,17 @@ chat_server <- function(
   ) {
     client_history <- arg_match(client_history)
 
+    hist_ctrl <- history_controller()
+    if (!is.null(hist_ctrl)) {
+      cli::cli_abort(
+        "Can't clear a chat with conversation history enabled. Use {.code chat$new_chat()} to start a new conversation."
+      )
+    }
+
     if (append_stream_task$status() == "running") {
       cli::cli_abort(
         "Can't clear the chat while a response is still being generated. Please wait for it to finish or stop it first."
       )
-    }
-
-    hist_ctrl <- history_controller()
-    if (
-      !is.null(hist_ctrl) &&
-        (!is.null(messages) || !identical(client_history, "clear"))
-    ) {
-      cli::cli_abort(c(
-        "{.fn chat_server}'s {.arg clear} only supports starting an empty new chat when history is enabled.",
-        "i" = "Set {.arg history} to {.val FALSE} to use {.arg messages} or a non-{.val clear} {.arg client_history} mode."
-      ))
-    }
-
-    if (!is.null(hist_ctrl)) {
-      hist_ctrl$new_chat(greeting = greeting)
-      last_turn(NULL)
-      last_input(NULL)
-      return(invisible())
     }
 
     if (!is.null(messages)) {
@@ -957,6 +955,25 @@ chat_server <- function(
     last_input(NULL)
   }
 
+  client_new_chat <- function(greeting = FALSE) {
+    hist_ctrl <- history_controller()
+    if (is.null(hist_ctrl)) {
+      cli::cli_abort(
+        "Can't start a new chat without conversation history enabled. Use {.code chat$clear()} instead."
+      )
+    }
+    if (append_stream_task$status() == "running") {
+      cli::cli_abort(
+        "Can't start a new chat while a response is still being generated. Please wait for it to finish or stop it first."
+      )
+    }
+
+    hist_ctrl$new_chat(greeting = greeting)
+    last_turn(NULL)
+    last_input(NULL)
+    invisible()
+  }
+
   ret <- new.env(parent = emptyenv())
   ret$last_turn <- shiny::reactive(last_turn(), label = "mod_last_turn")
   ret$last_input <- shiny::reactive(last_input(), label = "mod_last_input")
@@ -979,6 +996,7 @@ chat_server <- function(
   ret$append <- chat_append_mod
   ret$update_user_input <- chat_update_user_input
   ret$clear <- client_clear
+  ret$new_chat <- client_new_chat
   ret$set_greeting <- set_greeting_mod
   ret$set_client <- set_client
   ret$slash_command <- slash_command_method

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -96,14 +96,13 @@
 #'     * `append()`: A function to append a new message to the chat UI. Takes
 #'       the same arguments as [chat_append()], except for `id` and `session`,
 #'       which are supplied automatically.
-#'     * `clear()`: A function to clear the chat history and the chat UI.
-#'       `clear()` takes an optional list of `messages` used to initialize the
-#'       chat after clearing. `messages` should be a list of messages, where
-#'       each message is a list with `role` and `content` fields. The
-#'       `client_history` argument controls how the chat client's history is
-#'       updated after clearing. It can be one of: `"clear"` the chat history;
-#'       `"set"` the chat history to `messages`; `"append"` `messages` to the
-#'       existing chat history; or `"keep"` the existing chat history.
+#'     * `clear()`: A function to start a new chat by saving the current
+#'       conversation, clearing the chat client's turns and the chat UI, and
+#'       resetting the active conversation. When history is enabled, only the
+#'       empty new-chat form is supported: `messages` must be `NULL` and
+#'       `client_history` must be `"clear"`. Set `history = FALSE` to use the
+#'       other clearing modes. `clear(greeting = TRUE)` also clears the
+#'       greeting and requests a new one.
 #'     * `set_greeting()`: A function to set, stream, or clear the chat
 #'       greeting. Pass a [chat_greeting()] object, a plain string, or
 #'       `NULL` to clear. Streaming greetings run inside an
@@ -895,6 +894,24 @@ chat_server <- function(
     client_history = c("clear", "set", "append", "keep")
   ) {
     client_history <- arg_match(client_history)
+
+    hist_ctrl <- history_controller()
+    if (
+      !is.null(hist_ctrl) &&
+        (!is.null(messages) || !identical(client_history, "clear"))
+    ) {
+      cli::cli_abort(c(
+        "{.fn chat_server}'s {.arg clear} only supports starting an empty new chat when history is enabled.",
+        "i" = "Set {.arg history} to {.val FALSE} to use {.arg messages} or a non-{.val clear} {.arg client_history} mode."
+      ))
+    }
+
+    if (!is.null(hist_ctrl)) {
+      hist_ctrl$new_chat(greeting = greeting)
+      last_turn(NULL)
+      last_input(NULL)
+      return(invisible())
+    }
 
     if (!is.null(messages)) {
       if (rlang::is_string(messages)) {

--- a/pkg-r/R/chat_app.R
+++ b/pkg-r/R/chat_app.R
@@ -102,7 +102,8 @@
 #'       empty new-chat form is supported: `messages` must be `NULL` and
 #'       `client_history` must be `"clear"`. Set `history = FALSE` to use the
 #'       other clearing modes. `clear(greeting = TRUE)` also clears the
-#'       greeting and requests a new one.
+#'       greeting and requests a new one. `clear()` errors while a response is
+#'       streaming; wait for it to complete or stop it first.
 #'     * `set_greeting()`: A function to set, stream, or clear the chat
 #'       greeting. Pass a [chat_greeting()] object, a plain string, or
 #'       `NULL` to clear. Streaming greetings run inside an
@@ -894,6 +895,12 @@ chat_server <- function(
     client_history = c("clear", "set", "append", "keep")
   ) {
     client_history <- arg_match(client_history)
+
+    if (append_stream_task$status() == "running") {
+      cli::cli_abort(
+        "Can't clear the chat while a response is still being generated. Please wait for it to finish or stop it first."
+      )
+    }
 
     hist_ctrl <- history_controller()
     if (

--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -234,10 +234,14 @@ HistoryController <- R6::R6Class(
       self$send_history_update()
     },
 
-    new_chat = function() {
+    new_chat = function(greeting = FALSE) {
       self$save_current()
       private$client$set_turns(list())
-      chat_clear(private$chat_id, session = private$session)
+      chat_clear(
+        private$chat_id,
+        greeting = greeting,
+        session = private$session
+      )
       # Announce the cleared state even when the active ID is already NULL:
       # in URL/bookmark restore modes the browser may still carry a stale
       # conversation param (e.g. after a failed restore) that only

--- a/pkg-r/man/chat_app.Rd
+++ b/pkg-r/man/chat_app.Rd
@@ -84,14 +84,23 @@ except for \code{id} and \code{session}, which are supplied automatically.
 \item \code{append()}: A function to append a new message to the chat UI. Takes
 the same arguments as \code{\link[=chat_append]{chat_append()}}, except for \code{id} and \code{session},
 which are supplied automatically.
-\item \code{clear()}: A function to start a new chat by saving the current
-conversation, clearing the chat client's turns and the chat UI, and
-resetting the active conversation. When history is enabled, only the
-empty new-chat form is supported: \code{messages} must be \code{NULL} and
-\code{client_history} must be \code{"clear"}. Set \code{history = FALSE} to use the
-other clearing modes. \code{clear(greeting = TRUE)} also clears the
-greeting and requests a new one. \code{clear()} errors while a response is
-streaming; wait for it to complete or stop it first.
+\item \code{clear()}: A function to clear the chat client turns and the chat UI.
+It optionally takes a list of \code{messages} used to initialize the chat
+after clearing. \code{messages} should be a list of messages, where each
+message is a list with \code{role} and \code{content} fields. The
+\code{client_history} argument controls how the chat client's history is
+updated after clearing. It can be one of: \code{"clear"} the chat history;
+\code{"set"} the chat history to \code{messages}; \code{"append"} \code{messages} to the
+existing chat history; or \code{"keep"} the existing chat history.
+\code{clear()} is unavailable when conversation history is enabled; use
+\code{new_chat()} instead.
+\item \code{new_chat()}: A function to save the current conversation and start a
+new one by clearing the chat client's turns and chat UI, resetting the
+active conversation, and updating the history drawer. It is available
+only when conversation history is enabled. \code{new_chat(greeting = TRUE)}
+also clears the greeting and requests a new one. \code{new_chat()} errors
+while a response is streaming; wait for it to complete or stop it
+first.
 \item \code{set_greeting()}: A function to set, stream, or clear the chat
 greeting. Pass a \code{\link[=chat_greeting]{chat_greeting()}} object, a plain string, or
 \code{NULL} to clear. Streaming greetings run inside an

--- a/pkg-r/man/chat_app.Rd
+++ b/pkg-r/man/chat_app.Rd
@@ -90,7 +90,8 @@ resetting the active conversation. When history is enabled, only the
 empty new-chat form is supported: \code{messages} must be \code{NULL} and
 \code{client_history} must be \code{"clear"}. Set \code{history = FALSE} to use the
 other clearing modes. \code{clear(greeting = TRUE)} also clears the
-greeting and requests a new one.
+greeting and requests a new one. \code{clear()} errors while a response is
+streaming; wait for it to complete or stop it first.
 \item \code{set_greeting()}: A function to set, stream, or clear the chat
 greeting. Pass a \code{\link[=chat_greeting]{chat_greeting()}} object, a plain string, or
 \code{NULL} to clear. Streaming greetings run inside an

--- a/pkg-r/man/chat_app.Rd
+++ b/pkg-r/man/chat_app.Rd
@@ -84,14 +84,13 @@ except for \code{id} and \code{session}, which are supplied automatically.
 \item \code{append()}: A function to append a new message to the chat UI. Takes
 the same arguments as \code{\link[=chat_append]{chat_append()}}, except for \code{id} and \code{session},
 which are supplied automatically.
-\item \code{clear()}: A function to clear the chat history and the chat UI.
-\code{clear()} takes an optional list of \code{messages} used to initialize the
-chat after clearing. \code{messages} should be a list of messages, where
-each message is a list with \code{role} and \code{content} fields. The
-\code{client_history} argument controls how the chat client's history is
-updated after clearing. It can be one of: \code{"clear"} the chat history;
-\code{"set"} the chat history to \code{messages}; \code{"append"} \code{messages} to the
-existing chat history; or \code{"keep"} the existing chat history.
+\item \code{clear()}: A function to start a new chat by saving the current
+conversation, clearing the chat client's turns and the chat UI, and
+resetting the active conversation. When history is enabled, only the
+empty new-chat form is supported: \code{messages} must be \code{NULL} and
+\code{client_history} must be \code{"clear"}. Set \code{history = FALSE} to use the
+other clearing modes. \code{clear(greeting = TRUE)} also clears the
+greeting and requests a new one.
 \item \code{set_greeting()}: A function to set, stream, or clear the chat
 greeting. Pass a \code{\link[=chat_greeting]{chat_greeting()}} object, a plain string, or
 \code{NULL} to clear. Streaming greetings run inside an

--- a/pkg-r/man/chat_clear.Rd
+++ b/pkg-r/man/chat_clear.Rd
@@ -22,7 +22,7 @@ clear the greeting, which re-triggers \code{greeting_requested} (see the
 
 This is a UI-level primitive: it does not clear an ellmer client's turns or
 reset conversation history managed by \code{\link[=chat_server]{chat_server()}}. For a full reset of a
-managed chat, call the \code{clear()} method on the value returned by
+managed chat, call the \code{new_chat()} method on the value returned by
 \code{\link[=chat_server]{chat_server()}}.
 }
 \examples{

--- a/pkg-r/man/chat_clear.Rd
+++ b/pkg-r/man/chat_clear.Rd
@@ -19,6 +19,11 @@ allowing the server to generate a new greeting.}
 Removes all messages from the chat UI. Set \code{greeting = TRUE} to also
 clear the greeting, which re-triggers \code{greeting_requested} (see the
 \strong{Greeting} section in \code{\link[=chat_ui]{chat_ui()}}).
+
+This is a UI-level primitive: it does not clear an ellmer client's turns or
+reset conversation history managed by \code{\link[=chat_server]{chat_server()}}. For a full reset of a
+managed chat, call the \code{clear()} method on the value returned by
+\code{\link[=chat_server]{chat_server()}}.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}

--- a/pkg-r/tests/testthat/test-chat_history_integration.R
+++ b/pkg-r/tests/testthat/test-chat_history_integration.R
@@ -105,6 +105,54 @@ test_that("chat_server clear saves and separates history conversations", {
   )
 })
 
+test_that("chat_server clear rejects an in-flight response", {
+  skip_if_not_installed("ellmer")
+
+  client <- mock_chat_client()
+  chat_module <- NULL
+  resolve_stream <- NULL
+  client$stream_async <- function(...) {
+    promises::promise(function(resolve, reject) {
+      resolve_stream <<- resolve
+    })
+  }
+
+  shiny::testServer(
+    function(input, output, session) {
+      chat_module <<- chat_server(
+        "chat",
+        client,
+        history = history_options(store = "memory", title = NULL),
+        session = session
+      )
+    },
+    {
+      session$setInputs(
+        chat_history_browser_token = "browser-token",
+        chat_user_input = "first"
+      )
+      session$flushReact()
+
+      expect_identical(shiny::isolate(chat_module$status()), "streaming")
+      expect_error(
+        chat_module$clear(),
+        "Can't clear the chat while a response is still being generated"
+      )
+
+      resolve_stream("reply")
+      deadline <- Sys.time() + 5
+      while (
+        shiny::isolate(chat_module$status()) != "idle" &&
+          Sys.time() < deadline
+      ) {
+        later::run_now(0.05)
+        session$flushReact()
+      }
+      expect_identical(shiny::isolate(chat_module$status()), "idle")
+    }
+  )
+})
+
 test_that("chat_server clear(greeting = TRUE) forwards greeting clearing", {
   skip_if_not_installed("ellmer")
 

--- a/pkg-r/tests/testthat/test-chat_history_integration.R
+++ b/pkg-r/tests/testthat/test-chat_history_integration.R
@@ -42,6 +42,171 @@ test_that("chat_server() accepts history = FALSE", {
   )
 })
 
+clear_contract_turns <- function(user_text, assistant_text) {
+  list(
+    ellmer::UserTurn(
+      contents = list(ellmer::ContentText(user_text))
+    ),
+    ellmer::AssistantTurn(
+      contents = list(ellmer::ContentText(assistant_text))
+    )
+  )
+}
+
+test_that("chat_server clear saves and separates history conversations", {
+  skip_if_not_installed("ellmer")
+
+  store <- InMemoryConversationStore$new()
+  client <- mock_chat_client()
+  chat_module <- NULL
+
+  shiny::testServer(
+    function(input, output, session) {
+      chat_module <<- chat_server(
+        "chat",
+        client,
+        history = history_options(
+          store = store,
+          scope = "clear-test",
+          title = NULL,
+          restore_mode = "none"
+        ),
+        session = session
+      )
+    },
+    {
+      session$setInputs(chat_history_browser_token = "browser-token")
+      ctrl <- get_session_chat_bookmark_info(
+        session,
+        "chat.history-controller"
+      )
+      turns_one <- clear_contract_turns("first", "reply one")
+      client$set_turns(turns_one)
+      ctrl$on_response(lapply(turns_one, ellmer::contents_record))
+
+      first_id <- ctrl$record$id
+      first_record <- store$get(ctrl$partition, first_id)
+
+      chat_module$clear()
+
+      expect_null(ctrl$record)
+      expect_null(shiny::isolate(chat_module$history$conversation_id()))
+      expect_length(client$get_turns(), 0)
+      expect_identical(store$get(ctrl$partition, first_id), first_record)
+
+      turns_two <- clear_contract_turns("second", "reply two")
+      client$set_turns(turns_two)
+      ctrl$on_response(lapply(turns_two, ellmer::contents_record))
+
+      expect_false(identical(ctrl$record$id, first_id))
+      expect_identical(store$get(ctrl$partition, first_id), first_record)
+      expect_length(store$list(ctrl$partition), 2)
+    }
+  )
+})
+
+test_that("chat_server clear(greeting = TRUE) forwards greeting clearing", {
+  skip_if_not_installed("ellmer")
+
+  client <- mock_chat_client()
+  chat_module <- NULL
+  spy <- new.env(parent = emptyenv())
+  spy$messages <- list()
+
+  shiny::testServer(
+    function(input, output, session) {
+      session$sendCustomMessage <- function(type, message) {
+        spy$messages[[length(spy$messages) + 1L]] <<- list(
+          type = type,
+          message = message
+        )
+      }
+      chat_module <<- chat_server(
+        "chat",
+        client,
+        history = history_options(store = "memory", title = NULL),
+        session = session
+      )
+    },
+    {
+      chat_module$clear(greeting = TRUE)
+
+      clear_messages <- Filter(
+        function(x) identical(x$message$action$type, "clear"),
+        spy$messages
+      )
+      expect_length(clear_messages, 1)
+      expect_true(clear_messages[[1]]$message$action$greeting)
+    }
+  )
+})
+
+test_that("history-enabled chat_server clear rejects advanced modes", {
+  skip_if_not_installed("ellmer")
+
+  client <- mock_chat_client()
+  chat_module <- NULL
+
+  shiny::testServer(
+    function(input, output, session) {
+      chat_module <<- chat_server(
+        "chat",
+        client,
+        history = history_options(store = "memory", title = NULL),
+        session = session
+      )
+    },
+    {
+      expect_error(
+        chat_module$clear(
+          messages = list(list(role = "assistant", content = "seed"))
+        ),
+        "only supports starting an empty new chat"
+      )
+      expect_error(
+        chat_module$clear(client_history = "set"),
+        "only supports starting an empty new chat"
+      )
+      expect_error(
+        chat_module$clear(client_history = "append"),
+        "only supports starting an empty new chat"
+      )
+      expect_error(
+        chat_module$clear(client_history = "keep"),
+        "only supports starting an empty new chat"
+      )
+    }
+  )
+})
+
+test_that("history-disabled chat_server clear keeps client-history modes", {
+  skip_if_not_installed("ellmer")
+
+  client <- mock_chat_client(turns = list("existing"))
+  chat_module <- NULL
+
+  shiny::testServer(
+    function(input, output, session) {
+      chat_module <<- chat_server(
+        "chat",
+        client,
+        history = FALSE,
+        session = session
+      )
+    },
+    {
+      expect_no_error(chat_module$clear())
+      expect_length(client$get_turns(), 0)
+
+      expect_no_error(chat_module$clear(
+        messages = list(list(role = "assistant", content = "seed")),
+        client_history = "set"
+      ))
+      expect_length(client$get_turns(), 1)
+    }
+  )
+})
+
 test_that("chat_server() history save returns FALSE before a conversation exists", {
   skip_if_not_installed("ellmer")
 

--- a/pkg-r/tests/testthat/test-chat_history_integration.R
+++ b/pkg-r/tests/testthat/test-chat_history_integration.R
@@ -53,7 +53,7 @@ clear_contract_turns <- function(user_text, assistant_text) {
   )
 }
 
-test_that("chat_server clear saves and separates history conversations", {
+test_that("chat_server new_chat saves and separates history conversations", {
   skip_if_not_installed("ellmer")
 
   store <- InMemoryConversationStore$new()
@@ -87,7 +87,7 @@ test_that("chat_server clear saves and separates history conversations", {
       first_id <- ctrl$record$id
       first_record <- store$get(ctrl$partition, first_id)
 
-      chat_module$clear()
+      chat_module$new_chat()
 
       expect_null(ctrl$record)
       expect_null(shiny::isolate(chat_module$history$conversation_id()))
@@ -105,7 +105,7 @@ test_that("chat_server clear saves and separates history conversations", {
   )
 })
 
-test_that("chat_server clear rejects an in-flight response", {
+test_that("chat_server new_chat rejects an in-flight response", {
   skip_if_not_installed("ellmer")
 
   client <- mock_chat_client()
@@ -135,8 +135,8 @@ test_that("chat_server clear rejects an in-flight response", {
 
       expect_identical(shiny::isolate(chat_module$status()), "streaming")
       expect_error(
-        chat_module$clear(),
-        "Can't clear the chat while a response is still being generated"
+        chat_module$new_chat(),
+        "Can't start a new chat while a response is still being generated"
       )
 
       resolve_stream("reply")
@@ -153,7 +153,7 @@ test_that("chat_server clear rejects an in-flight response", {
   )
 })
 
-test_that("chat_server clear(greeting = TRUE) forwards greeting clearing", {
+test_that("chat_server new_chat(greeting = TRUE) forwards greeting clearing", {
   skip_if_not_installed("ellmer")
 
   client <- mock_chat_client()
@@ -177,7 +177,7 @@ test_that("chat_server clear(greeting = TRUE) forwards greeting clearing", {
       )
     },
     {
-      chat_module$clear(greeting = TRUE)
+      chat_module$new_chat(greeting = TRUE)
 
       clear_messages <- Filter(
         function(x) identical(x$message$action$type, "clear"),
@@ -189,7 +189,7 @@ test_that("chat_server clear(greeting = TRUE) forwards greeting clearing", {
   )
 })
 
-test_that("history-enabled chat_server clear rejects advanced modes", {
+test_that("history-enabled chat_server clear directs callers to new_chat", {
   skip_if_not_installed("ellmer")
 
   client <- mock_chat_client()
@@ -206,22 +206,50 @@ test_that("history-enabled chat_server clear rejects advanced modes", {
     },
     {
       expect_error(
+        chat_module$clear(),
+        "Use `chat\\$new_chat\\(\\)`"
+      )
+      expect_error(
         chat_module$clear(
           messages = list(list(role = "assistant", content = "seed"))
         ),
-        "only supports starting an empty new chat"
+        "Use `chat\\$new_chat\\(\\)`"
       )
       expect_error(
         chat_module$clear(client_history = "set"),
-        "only supports starting an empty new chat"
+        "Use `chat\\$new_chat\\(\\)`"
       )
       expect_error(
         chat_module$clear(client_history = "append"),
-        "only supports starting an empty new chat"
+        "Use `chat\\$new_chat\\(\\)`"
       )
       expect_error(
         chat_module$clear(client_history = "keep"),
-        "only supports starting an empty new chat"
+        "Use `chat\\$new_chat\\(\\)`"
+      )
+    }
+  )
+})
+
+test_that("history-disabled chat_server new_chat errors", {
+  skip_if_not_installed("ellmer")
+
+  client <- mock_chat_client()
+  chat_module <- NULL
+
+  shiny::testServer(
+    function(input, output, session) {
+      chat_module <<- chat_server(
+        "chat",
+        client,
+        history = FALSE,
+        session = session
+      )
+    },
+    {
+      expect_error(
+        chat_module$new_chat(),
+        "without conversation history enabled"
       )
     }
   )


### PR DESCRIPTION
Fixes #397

## Summary

- Add `new_chat()` to the managed R and Python chat handles. It saves the active conversation, clears the rendered messages and client turns, resets the active conversation ID, and refreshes the history drawer.
- Keep `clear()` as the lower-level UI/client-turn reset. It errors when conversation history is enabled and directs callers to `new_chat()`.
- Keep the low-level UI clear APIs UI-only, and document the distinction.
- Reject `new_chat()` while a response streams in R and Python, so a late response cannot enter the new conversation.

## Verification

- `make r-check`
- `make py-check`