### PR TITLE
fix: remove attachment content from restored messages

### DIFF
--- a/pkg-py/src/shinychat/_history.py
+++ b/pkg-py/src/shinychat/_history.py
@@ -205,7 +205,11 @@ def _strip_attachment_content(
 ) -> StoredUiMessage:
     """Remove model-facing attachment content from stored user UI."""
     attachments = message.get("attachments")
-    if message.get("role") != "user" or not attachments:
+    if (
+        message.get("role") != "user"
+        or not attachments
+        or message.get("attachment_content_stripped") is True
+    ):
         return message
 
     segments = [dict(segment) for segment in message["segments"]]
@@ -261,6 +265,7 @@ def _strip_attachment_content(
 
     cleaned = dict(message)
     cleaned["segments"] = cast(Any, segments)
+    cleaned["attachment_content_stripped"] = True
     return cast(StoredUiMessage, cleaned)
 
 
@@ -751,7 +756,9 @@ class HistoryController:
                 _strip_attachment_content(message) for message in stored
             ]
             for message_dict in stored:
-                await self.chat._restore_bookmark_message(message_dict)
+                restored_message = dict(message_dict)
+                restored_message.pop("attachment_content_stripped", None)
+                await self.chat._restore_bookmark_message(restored_message)
                 restored_count += 1
         # The restored messages are already in the server-side accumulator, so
         # start the offset after the messages restored into the record.

--- a/pkg-py/src/shinychat/_history.py
+++ b/pkg-py/src/shinychat/_history.py
@@ -5,7 +5,12 @@ import dataclasses
 import warnings
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, cast
 
-from ._attachments import Attachment, validate_attachments
+from ._attachments import (
+    Attachment,
+    attachment_to_content,
+    validate_attachments,
+)
+from ._chat_normalize import normalize_message
 from ._chat_types import (
     HistoryNavigateAction,
     HistoryUpdateAction,
@@ -195,6 +200,70 @@ def derive_stored_ui_message(
     return _stored_ui_dict(as_stored_message(msg, session))
 
 
+def _strip_attachment_content(
+    message: StoredUiMessage,
+) -> StoredUiMessage:
+    """Remove model-facing attachment content from stored user UI."""
+    attachments = message.get("attachments")
+    if message.get("role") != "user" or not attachments:
+        return message
+
+    segments = [dict(segment) for segment in message["segments"]]
+    attachment_segments: list[dict[str, Any]] = []
+    try:
+        for value in attachments:
+            attachment = Attachment.model_validate(value)
+            attachment_message = normalize_message(
+                attachment_to_content(attachment)
+            )
+            stored = _stored_ui_dict(
+                as_stored_message(attachment_message, session=None)
+            )
+            attachment_segments.extend(
+                cast(list[dict[str, Any]], stored["segments"])
+            )
+    except Exception:
+        # StoredMessage validation reports malformed attachments later. Do not
+        # make replay more fragile while cleaning records from older versions.
+        return message
+
+    for attachment_segment in reversed(attachment_segments):
+        if "type" in attachment_segment:
+            for index in range(len(segments) - 1, -1, -1):
+                if segments[index] == attachment_segment:
+                    segments.pop(index)
+                    break
+            continue
+
+        suffix = str(attachment_segment.get("content", ""))
+        if not suffix:
+            continue
+        for index in range(len(segments) - 1, -1, -1):
+            segment = segments[index]
+            if "type" in segment:
+                continue
+            content = str(segment.get("content", ""))
+            if content == suffix:
+                segment["content"] = ""
+                break
+            separator_suffix = f"\n\n{suffix}"
+            if content.endswith(separator_suffix):
+                segment["content"] = content[: -len(separator_suffix)]
+                break
+
+    segments = [
+        segment
+        for segment in segments
+        if "type" in segment or segment.get("content") != ""
+    ]
+    if not any("type" not in segment for segment in segments):
+        segments.insert(0, {"content": "", "content_type": "markdown"})
+
+    cleaned = dict(message)
+    cleaned["segments"] = cast(Any, segments)
+    return cast(StoredUiMessage, cleaned)
+
+
 def derive_node_ui(
     turns: list[TurnDict],
     session: Session | None = None,
@@ -269,6 +338,7 @@ def extend_record_linear(
             )
             if source and source.get("attachments"):
                 derived["attachments"] = source["attachments"]
+                derived = _strip_attachment_content(derived)
             record.nodes[node_id].ui = cast(list[dict[str, Any]], [derived])
             n_derived += 1
 
@@ -677,6 +747,9 @@ class HistoryController:
                 stored = derive_node_ui(
                     cast(list[TurnDict], node.turns), session=self.chat._session
                 )
+            stored = [
+                _strip_attachment_content(message) for message in stored
+            ]
             for message_dict in stored:
                 await self.chat._restore_bookmark_message(message_dict)
                 restored_count += 1

--- a/pkg-py/src/shinychat/_history.py
+++ b/pkg-py/src/shinychat/_history.py
@@ -200,6 +200,10 @@ def derive_stored_ui_message(
     return _stored_ui_dict(as_stored_message(msg, session))
 
 
+# Stopgap: turn-derived UI mixes model-facing attachment content into user
+# message bodies, so we re-serialize each attachment and subtract it here.
+# The feat/history-exchange-tree rewrite captures user messages as displayed
+# instead. Delete this and attachment_content_stripped when that lands.
 def _strip_attachment_content(
     message: StoredUiMessage,
 ) -> StoredUiMessage:

--- a/pkg-py/src/shinychat/_history_types.py
+++ b/pkg-py/src/shinychat/_history_types.py
@@ -44,6 +44,7 @@ class StoredUiMessage(TypedDict):
     segments: list[StoredSegmentDict | StructuredBlock]
     version: int
     attachments: NotRequired[list[AttachmentDict]]
+    attachment_content_stripped: NotRequired[bool]
 
 
 def new_conversation_record(

--- a/pkg-py/tests/test_history_controller.py
+++ b/pkg-py/tests/test_history_controller.py
@@ -2473,6 +2473,88 @@ async def test_replay_discards_old_format_ui_and_rederives_from_turns():
 
 
 @pytest.mark.anyio
+async def test_attachment_message_round_trips_through_history():
+    attachment = {
+        "mime": "text/plain",
+        "name": "notes.txt",
+        "size": 5,
+        "data_url": "data:text/plain;base64,aGVsbG8=",
+    }
+    store = InMemoryConversationStore()
+    partition = part()
+
+    chat = _TrackingChat()
+    adapter = _TrackingAdapter()
+    controller = HistoryController(
+        chat=chat,  # type: ignore[arg-type]
+        adapter=adapter,  # type: ignore[arg-type]
+        store=store,
+        title_fn=None,
+        title_enabled=False,
+        client=None,
+    )
+    controller.partition = partition
+    adapter.turns = [
+        {
+            "role": "user",
+            "contents": [
+                {"content_type": "text", "text": "See attached"},
+                {
+                    "content_type": "text",
+                    "text": (
+                        '<file-attachment name="notes.txt" '
+                        'type="text/plain">\n'
+                        "hello\n"
+                        "</file-attachment>"
+                    ),
+                },
+            ],
+        },
+        {"role": "assistant", "content": "Thanks"},
+    ]
+    chat.messages_ = [
+        {
+            "role": "user",
+            "segments": [
+                {"content": "See attached", "content_type": "markdown"}
+            ],
+            "attachments": [attachment],
+        },
+        {
+            "role": "assistant",
+            "segments": [{"content": "Thanks", "content_type": "markdown"}],
+        },
+    ]
+
+    await controller.on_response()
+    conversations = await store.list(partition)
+    assert len(conversations) == 1
+
+    restored_chat = _TrackingChat()
+    restored = HistoryController(
+        chat=restored_chat,  # type: ignore[arg-type]
+        adapter=_TrackingAdapter(),  # type: ignore[arg-type]
+        store=store,
+        title_fn=None,
+        title_enabled=False,
+        client=None,
+    )
+    restored.partition = partition
+    await restored.switch_to(conversations[0].id)
+
+    assert len(restored_chat.messages_) == 2
+    restored_user = restored_chat.messages_[0]
+    assert restored_user["role"] == "user"
+    assert restored_user["segments"] == [
+        {"content": "See attached", "content_type": "markdown"}
+    ]
+    assert restored_user["attachments"] == [attachment]
+    assert restored_chat.messages_[1]["segments"] == [
+        {"content": "Thanks", "content_type": "markdown"}
+    ]
+
+
+@pytest.mark.anyio
 async def test_replay_repairs_attachment_content_in_existing_record():
     attachment = {
         "mime": "text/plain",

--- a/pkg-py/tests/test_history_controller.py
+++ b/pkg-py/tests/test_history_controller.py
@@ -11,6 +11,7 @@ import pytest
 from _history_test_helpers import branch_from
 from shinychat._history import (
     HistoryController,
+    _strip_attachment_content,
     do_bookmark_with_cleanup,
     extend_record_linear,
 )
@@ -24,6 +25,7 @@ from shinychat._history_types import (
     MAX_SCHEMA_VERSION,
     STORED_UI_VERSION,
     ConversationRecord,
+    StoredUiMessage,
     UnsupportedSchemaVersionError,
     new_conversation_record,
 )
@@ -102,14 +104,57 @@ def test_extend_appends_only_new_groups_with_ui_by_role():
     assert rec.nodes[rec.path_node_ids()[2]].ui == [derived("user", "q2")]
 
 
-def test_extend_preserves_attachment_payload_from_ui_snapshot():
+@pytest.mark.parametrize(
+    ("attachment", "turn_content"),
+    [
+        (
+            {
+                "mime": "image/png",
+                "name": "plot.png",
+                "size": 3,
+                "data_url": "data:image/png;base64,QUJD",
+            },
+            {
+                "content_type": "image_inline",
+                "image_content_type": "image/png",
+                "data": "QUJD",
+            },
+        ),
+        (
+            {
+                "mime": "text/markdown",
+                "name": "notes.md",
+                "size": 7,
+                "data_url": "data:text/markdown;base64,IyBOb3Rlcw==",
+            },
+            {
+                "content_type": "text",
+                "text": (
+                    '<file-attachment name="notes.md" '
+                    'type="text/markdown">\n# Notes\n</file-attachment>'
+                ),
+            },
+        ),
+        (
+            {
+                "mime": "application/pdf",
+                "name": "report.pdf",
+                "size": 4,
+                "data_url": "data:application/pdf;base64,JVBERg==",
+            },
+            {
+                "content_type": "pdf",
+                "data": "JVBERg==",
+                "filename": "report.pdf",
+            },
+        ),
+    ],
+)
+def test_extend_preserves_attachment_without_model_content(
+    attachment: dict[str, object],
+    turn_content: dict[str, object],
+):
     rec = new_conversation_record(title="t")
-    attachment = {
-        "mime": "text/markdown",
-        "name": "notes.md",
-        "size": 7,
-        "data_url": "data:text/markdown;base64,IyBOb3Rlcw==",
-    }
     user_message = {
         "role": "user",
         "segments": [{"content": "See attached", "content_type": "markdown"}],
@@ -117,7 +162,17 @@ def test_extend_preserves_attachment_payload_from_ui_snapshot():
     }
     extend_record_linear(
         rec,
-        [[{"role": "user", "content": "See attached"}]],
+        [
+            [
+                {
+                    "role": "user",
+                    "contents": [
+                        {"content_type": "text", "text": "See attached"},
+                        turn_content,
+                    ],
+                }
+            ]
+        ],
         [user_message],
         ui_offset=0,
     )
@@ -125,6 +180,74 @@ def test_extend_preserves_attachment_payload_from_ui_snapshot():
     stored = rec.nodes[rec.path_node_ids()[0]].ui
     assert stored is not None
     assert stored[0]["attachments"] == [attachment]
+    assert stored[0]["segments"] == [
+        {"content": "See attached", "content_type": "markdown"}
+    ]
+
+
+def test_strip_attachment_content_repairs_existing_stored_ui():
+    attachment = {
+        "mime": "image/png",
+        "name": "plot.png",
+        "size": 3,
+        "data_url": "data:image/png;base64,QUJD",
+    }
+    stored = cast(
+        StoredUiMessage,
+        {
+            "version": STORED_UI_VERSION,
+            "role": "user",
+            "segments": [
+                {"content": "See attached", "content_type": "markdown"},
+                {
+                    "type": "html_block",
+                    "version": 1,
+                    "content": '<img src="data:image/png;base64,QUJD"/>',
+                },
+            ],
+            "attachments": [attachment],
+        },
+    )
+
+    cleaned = _strip_attachment_content(stored)
+
+    assert cleaned["segments"] == [
+        {"content": "See attached", "content_type": "markdown"}
+    ]
+
+
+def test_strip_attachment_content_keeps_empty_attachment_only_message():
+    attachment = {
+        "mime": "text/plain",
+        "name": "notes.txt",
+        "size": 5,
+        "data_url": "data:text/plain;base64,aGVsbG8=",
+    }
+    stored = cast(
+        StoredUiMessage,
+        {
+            "version": STORED_UI_VERSION,
+            "role": "user",
+            "segments": [
+                {
+                    "content": (
+                        '<file-attachment name="notes.txt" '
+                        'type="text/plain">\n'
+                        "hello\n"
+                        "</file-attachment>"
+                    ),
+                    "content_type": "markdown",
+                }
+            ],
+            "attachments": [attachment],
+        },
+    )
+
+    cleaned = _strip_attachment_content(stored)
+
+    assert cleaned["segments"] == [
+        {"content": "", "content_type": "markdown"}
+    ]
 
 
 def test_extend_groups_tool_exchange_into_single_node():
@@ -2343,6 +2466,56 @@ async def test_replay_discards_old_format_ui_and_rederives_from_turns():
     assert [s["type"] for s in asst["segments"] if "type" in s] == [
         "tool_request",
         "tool_result",
+    ]
+
+
+@pytest.mark.anyio
+async def test_replay_repairs_attachment_content_in_existing_record():
+    attachment = {
+        "mime": "text/plain",
+        "name": "notes.txt",
+        "size": 5,
+        "data_url": "data:text/plain;base64,aGVsbG8=",
+    }
+    rec = new_conversation_record(title="t")
+    rec.append_linear(
+        [],
+        ui=[
+            {
+                "version": STORED_UI_VERSION,
+                "role": "user",
+                "segments": [
+                    {
+                        "content": (
+                            "See attached\n\n"
+                            '<file-attachment name="notes.txt" '
+                            'type="text/plain">\n'
+                            "hello\n"
+                            "</file-attachment>"
+                        ),
+                        "content_type": "markdown",
+                    }
+                ],
+                "attachments": [attachment],
+            }
+        ],
+    )
+
+    chat = _TrackingChat()
+    controller, _store = _make_controller()
+    controller.chat = chat  # type: ignore[assignment]
+
+    await controller.replay_ui(rec)
+
+    assert chat.messages_ == [
+        {
+            "version": STORED_UI_VERSION,
+            "role": "user",
+            "segments": [
+                {"content": "See attached", "content_type": "markdown"}
+            ],
+            "attachments": [attachment],
+        }
     ]
 
 

--- a/pkg-py/tests/test_history_controller.py
+++ b/pkg-py/tests/test_history_controller.py
@@ -183,6 +183,7 @@ def test_extend_preserves_attachment_without_model_content(
     assert stored[0]["segments"] == [
         {"content": "See attached", "content_type": "markdown"}
     ]
+    assert stored[0]["attachment_content_stripped"] is True
 
 
 def test_strip_attachment_content_repairs_existing_stored_ui():
@@ -214,6 +215,7 @@ def test_strip_attachment_content_repairs_existing_stored_ui():
     assert cleaned["segments"] == [
         {"content": "See attached", "content_type": "markdown"}
     ]
+    assert cleaned.get("attachment_content_stripped") is True
 
 
 def test_strip_attachment_content_keeps_empty_attachment_only_message():
@@ -248,6 +250,7 @@ def test_strip_attachment_content_keeps_empty_attachment_only_message():
     assert cleaned["segments"] == [
         {"content": "", "content_type": "markdown"}
     ]
+    assert cleaned.get("attachment_content_stripped") is True
 
 
 def test_extend_groups_tool_exchange_into_single_node():
@@ -2516,6 +2519,62 @@ async def test_replay_repairs_attachment_content_in_existing_record():
             ],
             "attachments": [attachment],
         }
+    ]
+
+
+@pytest.mark.anyio
+async def test_replay_preserves_cleaned_text_matching_pdf_filename():
+    attachment = {
+        "mime": "application/pdf",
+        "name": "report.pdf",
+        "size": 4,
+        "data_url": "data:application/pdf;base64,JVBERg==",
+    }
+    rec = new_conversation_record(title="t")
+    extend_record_linear(
+        rec,
+        [
+            [
+                {
+                    "role": "user",
+                    "contents": [
+                        {"content_type": "text", "text": "report.pdf"},
+                        {
+                            "content_type": "pdf",
+                            "data": "JVBERg==",
+                            "filename": "report.pdf",
+                        },
+                    ],
+                }
+            ]
+        ],
+        [
+            {
+                "role": "user",
+                "segments": [
+                    {"content": "report.pdf", "content_type": "markdown"}
+                ],
+                "attachments": [attachment],
+            }
+        ],
+        ui_offset=0,
+    )
+    stored = rec.nodes[rec.path_node_ids()[0]].ui
+    assert stored is not None
+    assert stored[0]["attachment_content_stripped"] is True
+
+    chat = _TrackingChat()
+    controller, _store = _make_controller()
+    controller.chat = chat  # type: ignore[assignment]
+
+    await controller.replay_ui(rec)
+    assert chat.messages_[0]["segments"] == [
+        {"content": "report.pdf", "content_type": "markdown"}
+    ]
+
+    await controller.replay_ui(rec)
+    assert chat.messages_[0]["segments"] == [
+        {"content": "report.pdf", "content_type": "markdown"}
     ]
 
 

--- a/pkg-r/R/chat_history.R
+++ b/pkg-r/R/chat_history.R
@@ -325,6 +325,7 @@ HistoryController <- R6::R6Class(
               session = private$session
             )
           }
+          stored <- lapply(stored, strip_stored_attachment_content)
 
           for (message in stored) {
             restore_history_message(

--- a/pkg-r/R/chat_history_types.R
+++ b/pkg-r/R/chat_history_types.R
@@ -304,7 +304,11 @@ derive_stored_ui_messages <- function(live_groups, tools, session = NULL) {
 # content must not also appear in the message body.
 strip_stored_attachment_content <- function(message) {
   attachments <- message$attachments
-  if (!identical(message$role, "user") || length(attachments) == 0) {
+  if (
+    !identical(message$role, "user") ||
+      length(attachments) == 0 ||
+      isTRUE(message$attachment_content_stripped)
+  ) {
     return(message)
   }
 
@@ -371,6 +375,7 @@ strip_stored_attachment_content <- function(message) {
   }
 
   message$segments <- segments
+  message$attachment_content_stripped <- TRUE
   message
 }
 

--- a/pkg-r/R/chat_history_types.R
+++ b/pkg-r/R/chat_history_types.R
@@ -299,6 +299,81 @@ derive_stored_ui_messages <- function(live_groups, tools, session = NULL) {
   messages
 }
 
+# Remove the model-facing representation of user attachments from stored UI.
+# Attachment metadata renders the rich preview, so the corresponding turn
+# content must not also appear in the message body.
+strip_stored_attachment_content <- function(message) {
+  attachments <- message$attachments
+  if (!identical(message$role, "user") || length(attachments) == 0) {
+    return(message)
+  }
+
+  attachment_content <- lapply(attachments, function(attachment) {
+    tryCatch(
+      {
+        content <- content_from_attachment(attachment)
+        if (is.character(content)) {
+          return(as.character(content))
+        }
+        rendered <- contents_shinychat(content)
+        if (is.null(rendered)) NULL else as.character(rendered)
+      },
+      error = function(e) NULL
+    )
+  })
+  attachment_content <- Filter(
+    function(content) !is.null(content) && nzchar(content),
+    attachment_content
+  )
+
+  segments <- message$segments
+  for (suffix in rev(attachment_content)) {
+    for (i in rev(seq_along(segments))) {
+      segment <- segments[[i]]
+      if ("type" %in% names(segment)) {
+        next
+      }
+      content <- segment$content %||% ""
+      if (identical(content, suffix)) {
+        segments[[i]]$content <- ""
+        break
+      }
+      separator_suffix <- paste0("\n\n", suffix)
+      if (endsWith(content, separator_suffix)) {
+        segments[[i]]$content <- substr(
+          content,
+          1L,
+          nchar(content) - nchar(separator_suffix)
+        )
+        break
+      }
+    }
+  }
+
+  keep <- vapply(
+    segments,
+    function(segment) {
+      "type" %in% names(segment) || nzchar(segment$content %||% "")
+    },
+    logical(1)
+  )
+  segments <- segments[keep]
+  has_string_segment <- any(vapply(
+    segments,
+    function(segment) !"type" %in% names(segment),
+    logical(1)
+  ))
+  if (!has_string_segment) {
+    segments <- c(
+      list(list(content = "", content_type = "markdown")),
+      segments
+    )
+  }
+
+  message$segments <- segments
+  message
+}
+
 # Check whether a stored UI list carries the current version. Older or
 # unversioned UI returns FALSE and is discarded at replay time.
 is_stored_ui_versioned <- function(stored) {
@@ -592,6 +667,10 @@ extend_record_linear <- function(
     ))
     if (length(user_index) > 0) {
       derived_messages[[user_index[[1]]]]$attachments <- attachments
+      derived_messages[[user_index[[1]]]] <-
+        strip_stored_attachment_content(
+          derived_messages[[user_index[[1]]]]
+        )
     }
   }
 

--- a/pkg-r/R/chat_history_types.R
+++ b/pkg-r/R/chat_history_types.R
@@ -299,9 +299,10 @@ derive_stored_ui_messages <- function(live_groups, tools, session = NULL) {
   messages
 }
 
-# Remove the model-facing representation of user attachments from stored UI.
-# Attachment metadata renders the rich preview, so the corresponding turn
-# content must not also appear in the message body.
+# Stopgap: turn-derived UI mixes model-facing attachment content into user
+# message bodies, so we re-serialize each attachment and subtract it here.
+# The feat/history-exchange-tree rewrite captures user messages as displayed
+# instead. Delete this and attachment_content_stripped when that lands.
 strip_stored_attachment_content <- function(message) {
   attachments <- message$attachments
   if (

--- a/pkg-r/tests/testthat/helper-sync.R
+++ b/pkg-r/tests/testthat/helper-sync.R
@@ -1,6 +1,37 @@
+test_elapsed_seconds <- function() {
+  unname(proc.time()[["elapsed"]])
+}
+
+wait_until <- function(
+  condition,
+  timeout = 5,
+  interval = 0.05,
+  description = "condition"
+) {
+  deadline <- test_elapsed_seconds() + timeout
+
+  repeat {
+    if (isTRUE(condition())) {
+      return(invisible(TRUE))
+    }
+
+    remaining <- deadline - test_elapsed_seconds()
+    if (remaining <= 0) {
+      break
+    }
+    later::run_now(min(interval, remaining))
+  }
+
+  testthat::fail(sprintf(
+    "Timed out after %.1f seconds waiting for %s.",
+    timeout,
+    description
+  ))
+}
+
 # Given a promise-yielding expression, loop until it resolves or rejects.
 # DON'T USE THIS TECHNIQUE IN SHINY, PLUMBER, OR HTTPUV CONTEXTS.
-sync <- function(expr) {
+sync <- function(expr, timeout = 10) {
   p <- force(expr)
 
   done <- FALSE
@@ -19,9 +50,12 @@ sync <- function(expr) {
     }
   )
 
-  while (!done) {
-    later::run_now(0.25)
-  }
+  wait_until(
+    function() done,
+    timeout = timeout,
+    description = "promise to settle"
+  )
+
   if (!is.null(error)) {
     stop(error)
   } else {

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -99,6 +99,62 @@ test_that("replay_ui() clears the greeting", {
   expect_true("greeting_clear" %in% types)
 })
 
+test_that("replay_ui() repairs attachment content in existing records", {
+  spy <- history_mock_session_with_spy()
+  store <- InMemoryConversationStore$new()
+  client <- mock_chat_client()
+  ctrl <- HistoryController$new(
+    chat_id = "chat",
+    client = client,
+    options = history_options(store = store, title = NULL),
+    session = spy$session
+  )
+
+  attachment <- list(
+    mime = "text/plain",
+    name = "notes.txt",
+    size = 5L,
+    data_url = "data:text/plain;base64,aGVsbG8="
+  )
+  record <- new_conversation_record(title = "t")
+  record$nodes$n_0001 <- list(
+    parent = NULL,
+    children = list(),
+    turns = list(),
+    ui = list(list(
+      version = STORED_UI_VERSION,
+      role = "user",
+      segments = list(list(
+        content = paste0(
+          "See attached\n\n",
+          "<file-attachment name=\"notes.txt\" type=\"text/plain\">\n",
+          "hello\n",
+          "</file-attachment>"
+        ),
+        content_type = "markdown"
+      )),
+      attachments = list(attachment)
+    ))
+  )
+  record$current_leaf <- "n_0001"
+
+  ctrl$replay_ui(record)
+
+  message_actions <- Filter(
+    function(message) identical(message$message$action$type, "message"),
+    history_spy_messages(spy)
+  )
+  restored <- message_actions[[1]]$message$action$message
+  expect_equal(restored$attachments, list(attachment))
+  expect_equal(
+    restored$segments,
+    list(list(
+      content = "See attached",
+      content_type = "markdown"
+    ))
+  )
+})
+
 test_that("HistoryController$on_response() creates record on first save", {
   store <- InMemoryConversationStore$new()
   client <- mock_chat_client()

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -397,11 +397,15 @@ make_turns <- function(user_text = "Hi", asst_text = "Hello") {
   )
 }
 
-flush_promises <- function(timeout = 2) {
-  deadline <- Sys.time() + timeout
-  while (Sys.time() < deadline) {
-    later::run_now(0.05)
-  }
+wait_for_history_title <- function(ctrl, title, source, timeout = 5) {
+  wait_until(
+    function() {
+      identical(ctrl$record$title, title) &&
+        identical(ctrl$record$title_source, source)
+    },
+    timeout = timeout,
+    description = sprintf("history title %s to be applied", dQuote(title))
+  )
 }
 
 test_that("title stays fallback after first response", {
@@ -447,7 +451,7 @@ test_that("titling fires after the second response, exactly once", {
   ctrl$on_response(turns)
 
   expect_equal(ctrl$record$response_count, 2L)
-  flush_promises()
+  wait_for_history_title(ctrl, "Generated Title", "llm")
   expect_equal(ctrl$record$title, "Generated Title")
   expect_equal(ctrl$record$title_source, "llm")
 })
@@ -456,6 +460,10 @@ test_that("rename between the first and second response blocks auto-titling", {
   store <- InMemoryConversationStore$new()
   client <- mock_chat_client()
   session <- shiny::MockShinySession$new()
+  title_promise <- promises::promise_resolve("Generated Title")
+  local_mocked_bindings(
+    generate_title = function(...) title_promise
+  )
 
   ctrl <- HistoryController$new(
     chat_id = "chat",
@@ -473,7 +481,14 @@ test_that("rename between the first and second response blocks auto-titling", {
 
   turns <- c(make_turns("Hi", "Hello"), make_turns("More", "Sure"))
   ctrl$on_response(turns)
-  flush_promises()
+  title_callback_finished <- FALSE
+  promises::then(title_promise, function(...) {
+    title_callback_finished <<- TRUE
+  })
+  wait_until(
+    function() title_callback_finished,
+    description = "automatic title callback to finish"
+  )
 
   expect_equal(ctrl$record$title, "My Title")
   expect_equal(ctrl$record$title_source, "user")
@@ -515,7 +530,7 @@ test_that("titling fires on the second response across sessions", {
 
   turns <- c(make_turns("Hi", "Hello"), make_turns("More", "Sure"))
   ctrl2$on_response(turns)
-  flush_promises()
+  wait_for_history_title(ctrl2, "Generated Title", "llm")
 
   expect_equal(ctrl2$record$title, "Generated Title")
   expect_equal(ctrl2$record$title_source, "llm")

--- a/pkg-r/tests/testthat/test-chat_history.R
+++ b/pkg-r/tests/testthat/test-chat_history.R
@@ -155,6 +155,61 @@ test_that("replay_ui() repairs attachment content in existing records", {
   )
 })
 
+test_that("replay_ui() preserves cleaned text matching a PDF filename", {
+  spy <- history_mock_session_with_spy()
+  store <- InMemoryConversationStore$new()
+  client <- mock_chat_client()
+  ctrl <- HistoryController$new(
+    chat_id = "chat",
+    client = client,
+    options = history_options(store = store, title = NULL),
+    session = spy$session
+  )
+
+  attachment <- list(
+    mime = "application/pdf",
+    name = "report.pdf",
+    size = 4L,
+    data_url = "data:application/pdf;base64,JVBERg=="
+  )
+  contents <- list(
+    ellmer::ContentText("report.pdf"),
+    content_from_attachment(attachment)
+  )
+  turns <- list(ellmer::contents_record(ellmer::UserTurn(contents)))
+  record <- extend_record_linear(
+    new_conversation_record("test"),
+    turns,
+    tools = list(),
+    attachments = list(attachment)
+  )
+  expect_true(
+    record$nodes$n_0001$ui[[1]]$attachment_content_stripped
+  )
+
+  ctrl$replay_ui(record)
+  ctrl$replay_ui(record)
+
+  message_actions <- Filter(
+    function(message) identical(message$message$action$type, "message"),
+    history_spy_messages(spy)
+  )
+  restored <- lapply(
+    message_actions,
+    function(action) action$message$action$message$segments
+  )
+  expect_equal(
+    restored,
+    rep(
+      list(list(list(
+        content = "report.pdf",
+        content_type = "markdown"
+      ))),
+      2L
+    )
+  )
+})
+
 test_that("HistoryController$on_response() creates record on first save", {
   store <- InMemoryConversationStore$new()
   client <- mock_chat_client()

--- a/pkg-r/tests/testthat/test-chat_history_integration.R
+++ b/pkg-r/tests/testthat/test-chat_history_integration.R
@@ -92,14 +92,24 @@ test_that("chat_server new_chat saves and separates history conversations", {
       expect_null(ctrl$record)
       expect_null(shiny::isolate(chat_module$history$conversation_id()))
       expect_length(client$get_turns(), 0)
-      expect_identical(store$get(ctrl$partition, first_id), first_record)
+      saved_first_record <- store$get(ctrl$partition, first_id)
+      first_record$updated_at <- NULL
+      saved_first_record_without_timestamp <- saved_first_record
+      saved_first_record_without_timestamp$updated_at <- NULL
+      expect_identical(
+        saved_first_record_without_timestamp,
+        first_record
+      )
 
       turns_two <- clear_contract_turns("second", "reply two")
       client$set_turns(turns_two)
       ctrl$on_response(lapply(turns_two, ellmer::contents_record))
 
       expect_false(identical(ctrl$record$id, first_id))
-      expect_identical(store$get(ctrl$partition, first_id), first_record)
+      expect_identical(
+        store$get(ctrl$partition, first_id),
+        saved_first_record
+      )
       expect_length(store$list(ctrl$partition), 2)
     }
   )

--- a/pkg-r/tests/testthat/test-chat_history_types.R
+++ b/pkg-r/tests/testthat/test-chat_history_types.R
@@ -532,6 +532,7 @@ test_that("extend_record_linear() stores attachment previews without model conte
       content_type = "markdown"
     ))
   )
+  expect_true(stored$attachment_content_stripped)
 })
 
 test_that("strip_stored_attachment_content repairs existing stored UI", {
@@ -565,6 +566,7 @@ test_that("strip_stored_attachment_content repairs existing stored UI", {
       content_type = "markdown"
     ))
   )
+  expect_true(cleaned$attachment_content_stripped)
 })
 
 test_that("attachment-only stored UI retains an empty message segment", {
@@ -597,6 +599,7 @@ test_that("attachment-only stored UI retains an empty message segment", {
       content_type = "markdown"
     ))
   )
+  expect_true(cleaned$attachment_content_stripped)
 })
 
 test_that("extend_record_linear() derives UI with structured blocks from tool-call turns", {

--- a/pkg-r/tests/testthat/test-chat_history_types.R
+++ b/pkg-r/tests/testthat/test-chat_history_types.R
@@ -492,6 +492,113 @@ test_that("extend_record_linear() derives UI from turns and attaches to matching
   expect_equal(rec$nodes$n_0002$ui[[1]]$segments[[1]]$content, "hello")
 })
 
+test_that("extend_record_linear() stores attachment previews without model content", {
+  attachments <- list(
+    list(
+      mime = "image/png",
+      name = "plot.png",
+      size = 3L,
+      data_url = "data:image/png;base64,QUJD"
+    ),
+    list(
+      mime = "text/plain",
+      name = "notes.txt",
+      size = 5L,
+      data_url = "data:text/plain;base64,aGVsbG8="
+    )
+  )
+  contents <- c(
+    list(ellmer::ContentText("See attached")),
+    lapply(attachments, function(attachment) {
+      content <- content_from_attachment(attachment)
+      if (is.character(content)) ellmer::ContentText(content) else content
+    })
+  )
+  turns <- list(ellmer::contents_record(ellmer::UserTurn(contents)))
+
+  rec <- extend_record_linear(
+    new_conversation_record("test"),
+    turns,
+    tools = list(),
+    attachments = attachments
+  )
+
+  stored <- rec$nodes$n_0001$ui[[1]]
+  expect_equal(stored$attachments, attachments)
+  expect_equal(
+    stored$segments,
+    list(list(
+      content = "See attached",
+      content_type = "markdown"
+    ))
+  )
+})
+
+test_that("strip_stored_attachment_content repairs existing stored UI", {
+  attachment <- list(
+    mime = "text/plain",
+    name = "notes.txt",
+    size = 5L,
+    data_url = "data:text/plain;base64,aGVsbG8="
+  )
+  stored <- list(
+    version = STORED_UI_VERSION,
+    role = "user",
+    segments = list(list(
+      content = paste0(
+        "See attached\n\n",
+        "<file-attachment name=\"notes.txt\" type=\"text/plain\">\n",
+        "hello\n",
+        "</file-attachment>"
+      ),
+      content_type = "markdown"
+    )),
+    attachments = list(attachment)
+  )
+
+  cleaned <- strip_stored_attachment_content(stored)
+
+  expect_equal(
+    cleaned$segments,
+    list(list(
+      content = "See attached",
+      content_type = "markdown"
+    ))
+  )
+})
+
+test_that("attachment-only stored UI retains an empty message segment", {
+  attachment <- list(
+    mime = "text/plain",
+    name = "notes.txt",
+    size = 5L,
+    data_url = "data:text/plain;base64,aGVsbG8="
+  )
+  stored <- list(
+    version = STORED_UI_VERSION,
+    role = "user",
+    segments = list(list(
+      content = paste0(
+        "<file-attachment name=\"notes.txt\" type=\"text/plain\">\n",
+        "hello\n",
+        "</file-attachment>"
+      ),
+      content_type = "markdown"
+    )),
+    attachments = list(attachment)
+  )
+
+  cleaned <- strip_stored_attachment_content(stored)
+
+  expect_equal(
+    cleaned$segments,
+    list(list(
+      content = "",
+      content_type = "markdown"
+    ))
+  )
+})
+
 test_that("extend_record_linear() derives UI with structured blocks from tool-call turns", {
   rec <- new_conversation_record("test")
   turns <- list(

--- a/pkg-r/tests/testthat/test-greeting.R
+++ b/pkg-r/tests/testthat/test-greeting.R
@@ -228,17 +228,23 @@ test_that("chat_set_greeting() generator sends greeting_start, greeting_chunk(s)
   shiny::withReactiveDomain(spy$session, {
     p <- chat_set_greeting("chat", chat_greeting(gen()), session = spy$session)
     done <- FALSE
+    error <- NULL
     promises::then(
       p,
       function(x) {
         done <<- TRUE
       },
       function(e) {
+        error <<- e
         done <<- TRUE
       }
     )
-    while (!done) {
-      later::run_now(0.1)
+    wait_until(
+      function() done,
+      description = "greeting stream to finish"
+    )
+    if (!is.null(error)) {
+      stop(error)
     }
   })
   msgs <- spy_messages(spy)


### PR DESCRIPTION
Follow-up to #394.

## Summary

- Remove model-facing image, PDF, and text attachment content from restored message bodies.
- Preserve rich attachment previews and user-entered text.
- Repair records already saved with duplicated attachment content during replay.
- Cover mixed attachments and attachment-only messages in Python and R.

## Verification

Attach an image or text file, save the conversation, and restore it. The attachment preview remains, while the message body contains only the text entered by the user.

- `make py-check-unit FILTER='history'`
- `make py-check-types`
- `make py-check-format`
- `make r-check-tests FILTER='chat_history'`
- `make r-check-format`
